### PR TITLE
Download the package with rust, make assumptions about output path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,10 +1640,13 @@ dependencies = [
  "base64 0.10.1",
  "env_logger",
  "rebuilderd-common",
+ "reqwest",
  "serde",
  "sodiumoxide",
  "structopt",
+ "tempfile",
  "toml",
+ "url",
 ]
 
 [[package]]

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -17,3 +17,6 @@ sodiumoxide = { version="0.2.5", features=["use-pkg-config"] }
 base64 = "0.10"
 toml = "0.5.6"
 serde = { version="1.0", features=["derive"] }
+reqwest = "0.10.4"
+tempfile = "3.1.0"
+url = "2.1.1"

--- a/worker/rebuilder-archlinux.sh
+++ b/worker/rebuilder-archlinux.sh
@@ -1,7 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 set -xe
-dir=$(mktemp -dt rebuild.XXXXXXXXXX)
-trap 'rm -r "$dir"' EXIT
-wget -P "${dir}" -- "${1}"
-file=$(basename "${1}")
-repro -- "${dir}/${file}"
+repro -- "${1}"

--- a/worker/rebuilder-archlinux.sh
+++ b/worker/rebuilder-archlinux.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -xe
-repro -- "${1}"
+repro -- "${2}"

--- a/worker/src/rebuild.rs
+++ b/worker/src/rebuild.rs
@@ -1,0 +1,82 @@
+use rebuilderd_common::errors::*;
+use rebuilderd_common::Distro;
+use std::fs::File;
+use std::process::Command;
+use std::path::{Path};
+use url::Url;
+
+pub fn rebuild(distro: &Distro, url: &str) -> Result<bool> {
+    let tmp = tempfile::Builder::new().prefix("rebuilderd").tempdir()?;
+
+    let url = url.parse::<Url>()
+        .context("Failed to parse input as url")?;
+
+    let filename = url.path_segments()
+        .ok_or_else(|| format_err!("Url doesn't seem to have a path"))?
+        .last()
+        .ok_or_else(|| format_err!("Failed to get filename from path"))?;
+    if filename.is_empty() {
+        bail!("Filename is empty");
+    }
+
+    let input = tmp.path().join(filename);
+    download(&url, &input)
+        .context("Failed to download original package")?;
+    let input = input.to_str()
+        .ok_or_else(|| format_err!("Input path contains invalid characters"))?;
+
+    if !spawn_script(distro, &url.to_string(), input)? {
+        return Ok(false);
+    }
+    info!("rebuilder script indicated success");
+
+    let output = Path::new("./build/").join(filename);
+    if !output.exists() {
+        bail!("Rebuild script exited successfully but output package does not exist");
+    }
+
+    // TODO: diff files. this is already done by the rebuilder script right now, but we'd rather do it here
+
+    Ok(true)
+}
+
+fn download(url: &Url, target: &Path) -> Result<()> {
+    info!("Downloading {:?} to {:?}", url, target);
+    let client = reqwest::blocking::Client::new();
+    let mut response = client.get(&url.to_string())
+        .send()?
+        .error_for_status()?;
+
+    let mut f = File::create(target)
+        .context("Failed to create output file")?;
+    let n = response.copy_to(&mut f)
+        .context("Failed to download")?;
+    info!("Downloaded {} bytes", n);
+
+    Ok(())
+}
+
+fn spawn_script(distro: &Distro, url: &str, path: &str) -> Result<bool> {
+    // TODO: establish a common interface to interface with distro rebuilders
+    let bin = match distro {
+        Distro::Archlinux => "rebuilder-archlinux.sh",
+        Distro::Debian => "rebuilder-debian.sh",
+    };
+
+    for prefix in &[".", "/usr/libexec/rebuilderd", "/usr/local/libexec/rebuilderd"] {
+        let bin = format!("{}/{}", prefix, bin);
+        let bin = Path::new(&bin);
+
+        if bin.exists() {
+            info!("executing rebuilder script at {:?}", bin);
+            let status = Command::new(&bin)
+                .args(&[url, path])
+                .status()?;
+
+            info!("rebuilder script finished: {:?} (for {:?}, {:?})", status, url, path);
+            return Ok(status.success());
+        }
+    }
+
+    bail!("failed to find a rebuilder script")
+}


### PR DESCRIPTION
This allows us to extend rebuilderd to access both the input file and the output file.