### PR TITLE
Add cargo fmt to github actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,8 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get install libsodium-dev libsqlite3-dev
 
+    - name: Run cargo fmt
+      run: cargo fmt -- --check
     - name: Build
       run: cargo build --verbose
     - name: Run tests


### PR DESCRIPTION
Note: This PR can be merged after https://github.com/kpcyrd/rebuilderd/pull/24 to fix the `cargo fmt`  build failure.