### PR TITLE
Automatic retries and queue priorities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "actix-macros"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21705adc76bbe4bc98434890e73a89cd00c6015e5704a60bb6eea6c3b72316b6"
+checksum = "a60f9ba7c4e6df97f3aacb14bb5c0cd7d98a49dcbaed0d7f292912ad9a6a3ed2"
 dependencies = [
  "quote",
  "syn",
@@ -121,21 +121,22 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "582a7173c281a4f46b5aa168a11e7f37183dcb71177a39312cc2264da7a632c9"
+checksum = "e6d74b464215a473c973a2d7d03a69cc10f4ce1f4b38a7659c5193dc5c675630"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
- "futures",
+ "futures-channel",
+ "futures-util",
  "log",
  "mio",
  "mio-uds",
- "net2",
  "num_cpus",
  "slab",
+ "socket2",
 ]
 
 [[package]]
@@ -150,24 +151,23 @@ dependencies = [
 
 [[package]]
 name = "actix-testing"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48494745b72d0ea8ff0cf874aaf9b622a3ee03d7081ee0c04edea4f26d32c911"
+checksum = "47239ca38799ab74ee6a8a94d1ce857014b2ac36f242f70f3f75a66f691e791c"
 dependencies = [
  "actix-macros",
  "actix-rt",
  "actix-server",
  "actix-service",
- "futures",
  "log",
- "net2",
+ "socket2",
 ]
 
 [[package]]
 name = "actix-threadpool"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4082192601de5f303013709ff84d81ca6a1bc4af7fb24f367a500a23c6e84e"
+checksum = "91164716d956745c79dcea5e66d2aa04506549958accefcede5368c70f2fd4ff"
 dependencies = [
  "derive_more",
  "futures-channel",
@@ -250,13 +250,22 @@ dependencies = [
 
 [[package]]
 name = "actix-web-codegen"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f00371942083469785f7e28c540164af1913ee7c96a4534acb9cea92c39f057"
+checksum = "a71bf475cbe07281d0b3696abb48212db118e7e23219f13596ce865235ff5766"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
+dependencies = [
+ "gimli",
 ]
 
 [[package]]
@@ -312,9 +321,9 @@ checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "async-trait"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da71fef07bc806586090247e971229289f64c210a278ee5ae419314eb386b31d"
+checksum = "26c4f3195085c36ea8d24d32b2f828d23296a9370a28aa39d111f6f16bef9f3b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -363,24 +372,15 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.46"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
+checksum = "0df2f85c8a2abbe3b7d7e748052fdd9b76a0458fdeb16ad4223f5eca78c7c130"
 dependencies = [
- "backtrace-sys",
+ "addr2line",
  "cfg-if",
  "libc",
+ "object",
  "rustc-demangle",
-]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fbebbe1c9d1f383a9cc7e8ccdb471b91c8d024ee9c2ca5b5346121fe8b4399"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -437,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
+checksum = "5356f1d23ee24a1f785a56d1d1a5f0fd5b0f6a0c0fb2412ce11da71649ab78f6"
 
 [[package]]
 name = "byteorder"
@@ -464,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.52"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d"
+checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
 
 [[package]]
 name = "cfg-if"
@@ -488,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.0"
+version = "2.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
 dependencies = [
  "ansi_term",
  "atty",
@@ -571,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.5"
+version = "0.99.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2323f3f47db9a0e77ce7a300605d8d2098597fc451ed1a97bb1f6411bb550a7"
+checksum = "2127768764f1556535c01b5326ef94bd60ff08dcfbdc544d53e69ed155610f5d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -656,9 +656,9 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28"
+checksum = "e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171"
 dependencies = [
  "cfg-if",
 ]
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "failure"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8529c2421efa3066a5cbd8063d2244603824daccb6936b079010bb2aa89464b"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
 dependencies = [
  "backtrace",
  "failure_derive",
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "failure_derive"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -712,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59efc38004c988e4201d11d263b8171f49a2e7ec0bdbb71773433f271504a5e"
+checksum = "affc17579b132fc2461adf7c575cc6e8b134ebca52c51f5411388965227dc695"
 dependencies = [
  "cfg-if",
  "libc",
@@ -736,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "fnv"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
@@ -773,9 +773,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c329ae8753502fb44ae4fc2b622fa2a94652c41e795143765ba0927f92ab780"
+checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -788,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c77d04ce8edd9cb903932b608268b3fffec4163dc053b3b402bf47eac1f1a8"
+checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -798,15 +798,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
+checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f674f3e1bcb15b37284a90cedf55afdba482ab061c407a9c0ebbd0f3109741ba"
+checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -815,15 +815,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a638959aa96152c7a4cddf50fcb1e3fede0583b27157c26e67d6f99904090dc6"
+checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
+checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -833,21 +833,24 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
+checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
 
 [[package]]
 name = "futures-task"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
+checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "futures-util"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
+checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -856,6 +859,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
+ "pin-project",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -883,6 +887,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,9 +900,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377038bf3c89d18d6ca1431e7a5027194fbd724ca10592b9487ede5e8e144f42"
+checksum = "79b7246d7e4b979c03fa093da39cfb3617a96bbeee6310af63991668d7e843ff"
 dependencies = [
  "bytes",
  "fnv",
@@ -918,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
+checksum = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
 dependencies = [
  "libc",
 ]
@@ -1058,9 +1068,9 @@ checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 
 [[package]]
 name = "js-sys"
-version = "0.3.38"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b823ebafcee1632403f2782d28728aab353f7881547a700043ef455c078326f"
+checksum = "fa5a448de267e7358beaf4a5d849518fe9a0c13fce7afd44b06e68550e5562a7"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1102,9 +1112,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.69"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
+checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 
 [[package]]
 name = "libflate"
@@ -1144,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
+checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
 name = "lock_api"
@@ -1241,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
+checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
  "cfg-if",
  "fuchsia-zircon",
@@ -1260,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "mio-uds"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
+checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
@@ -1301,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1357,6 +1367,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
+
+[[package]]
+name = "once_cell"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
+
+[[package]]
 name = "openssl"
 version = "0.10.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1378,9 +1400,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.55"
+version = "0.9.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7717097d810a0f2e2323f9e5d11e71608355e24828410b55b9d4f18aa5f9a5d8"
+checksum = "7410fef80af8ac071d4f63755c0ab89ac3df0fd1ea91f1d1f37cf5cec4395990"
 dependencies = [
  "autocfg",
  "cc",
@@ -1421,18 +1443,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "0.4.9"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f6a7f5eee6292c559c793430c55c00aea9d3b3d1905e855806ca4d7253426a2"
+checksum = "edc93aeee735e60ecb40cf740eb319ff23eab1c5748abfdb5c180e4ce49f7791"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.9"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8988430ce790d8682672117bc06dda364c0be32d3abd738234f19f3240bad99a"
+checksum = "e58db2081ba5b4c93bd6be09c40fd36cb9193a8336c384f3b40012e531aa7e40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1441,9 +1463,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
+checksum = "f7505eeebd78492e0f6108f7171c4948dbb120ee8119d9d77d0afa5469bef67f"
 
 [[package]]
 name = "pin-utils"
@@ -1459,9 +1481,9 @@ checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "proc-macro-error"
@@ -1491,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63"
+checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
 name = "proc-macro-nested"
@@ -1503,9 +1525,9 @@ checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.10"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
+checksum = "1502d12e458c49a4c9cbff560d0fe0060c252bc29799ed94ca2ed4bb665a0101"
 dependencies = [
  "unicode-xid",
 ]
@@ -1518,9 +1540,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
 dependencies = [
  "proc-macro2",
 ]
@@ -1789,9 +1811,9 @@ checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 
 [[package]]
 name = "schannel"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039c25b130bd8c1321ee2d7de7fde2659fa9c2744e4bb29711cfc852ea53cd19"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
  "winapi 0.3.8",
@@ -1814,9 +1836,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f331b9025654145cd425b9ded0caf8f5ae0df80d418b326e2dc1c3dc5eb0620"
+checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1852,18 +1874,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.106"
+version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
+checksum = "99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.106"
+version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
+checksum = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1872,9 +1894,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
+checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
 dependencies = [
  "itoa",
  "ryu",
@@ -2000,9 +2022,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.18"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
+checksum = "ef781e621ee763a2a40721a8861ec519cb76966aee03bb5d00adb6a31dc1c1de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2040,9 +2062,9 @@ checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "tar"
-version = "0.4.26"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
+checksum = "5c058ad0bd6ccb84faa24cc44d4fc99bee8a5d7ba9ff33aa4d993122d1aeeac2"
 dependencies = [
  "filetime",
  "libc",
@@ -2093,9 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "threadpool"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dae184447c15d5a6916d973c642aec485105a13cd238192a6927ae3e077d66"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
 ]
@@ -2112,9 +2134,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c1d570eb1a36f0345a5ce9c6c6e665b70b73d11236912c0b477616aeec47b1"
+checksum = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
 dependencies = [
  "bytes",
  "fnv",
@@ -2134,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tls"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bde02a3a5291395f59b06ec6945a3077602fac2b07eeeaf0dee2122f3619828"
+checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
  "tokio",
@@ -2294,15 +2316,15 @@ checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 
 [[package]]
 name = "vec_map"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "want"
@@ -2322,9 +2344,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.61"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56e97dbea16d5f56549d6c8ea7f36efb6be98507308650c1a5970574b3941b9"
+checksum = "e3c7d40d09cdbf0f4895ae58cf57d92e1e57a9dd8ed2e8390514b54a47cc5551"
 dependencies = [
  "cfg-if",
  "serde",
@@ -2334,9 +2356,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.61"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75d4f3f9b81dfc7d66b955876b325b20e8affd4ce8d93e51162626fc5faadb"
+checksum = "c3972e137ebf830900db522d6c8fd74d1900dcfc733462e9a12e942b00b4ac94"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2349,9 +2371,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736dcd8f8455458c82614f12116aabd0209d440c1a28d8824bcaed755ac3e058"
+checksum = "8a369c5e1dfb7569e14d62af4da642a3cbc2f9a3652fe586e26ac22222aa4b04"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2361,9 +2383,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.61"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcde4b19e863521c1e78ecf100935132396291b09ae0ae2e155ff84ccbe9736"
+checksum = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2371,9 +2393,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.61"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d87d2b117af2b86472402d70f7eb173bbe166beb5e727f3c0bebecdf356504"
+checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2384,15 +2406,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.61"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71f77b681efd0bca6f8ea356cdc2e497538b41d3e2a02afed18ce8f022231d29"
+checksum = "a91c2916119c17a8e316507afaaa2dd94b47646048014bbdf6bef098c1bb58ad"
 
 [[package]]
 name = "web-sys"
-version = "0.3.38"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c5819dc39222a788ca169a81aef7d02739019256300534f493b5747d5469c2"
+checksum = "8bc359e5dd3b46cb9687a051d50a2fdd228e4ba7cf6fcf861a5365c3d671a642"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/common/src/api.rs
+++ b/common/src/api.rs
@@ -273,7 +273,7 @@ pub struct RequeueQuery {
     pub reset: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum BuildStatus {
     Good,
     Bad,
@@ -281,7 +281,22 @@ pub enum BuildStatus {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct Rebuild {
+    pub status: BuildStatus,
+    pub diffoscope: Option<String>,
+}
+
+impl Rebuild {
+    pub fn new(status: BuildStatus) -> Rebuild {
+        Rebuild {
+            status,
+            diffoscope: None,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct BuildReport {
     pub queue: QueueItem,
-    pub status: BuildStatus,
+    pub rebuild: Rebuild,
 }

--- a/common/src/api.rs
+++ b/common/src/api.rs
@@ -249,6 +249,7 @@ pub struct ListQueue {
 pub struct PushQueue {
     pub name: String,
     pub version: Option<String>,
+    pub priority: i32,
     pub distro: String,
     pub suite: String,
     pub architecture: Option<String>,
@@ -267,6 +268,7 @@ pub struct DropQueueItem {
 pub struct RequeueQuery {
     pub name: Option<String>,
     pub status: Option<Status>,
+    pub priority: i32,
     pub distro: Option<String>,
     pub suite: Option<String>,
     pub architecture: Option<String>,

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -11,6 +11,8 @@ pub const PING_INTERVAL: u64 = 60;
 pub const WORKER_DELAY: u64 = 3;
 pub const API_ERROR_DELAY: u64 = 30;
 
+pub const DEFAULT_RETRY_DELAY_BASE: i64 = 24;
+
 pub fn load<P: AsRef<Path>>(path: Option<P>) -> Result<ConfigFile> {
     let mut config = ConfigFile::default();
 
@@ -60,6 +62,8 @@ pub struct ConfigFile {
     pub endpoints: HashMap<String, EndpointConfig>,
     #[serde(default)]
     pub worker: WorkerConfig,
+    #[serde(default)]
+    pub schedule: ScheduleConfig,
 }
 
 impl ConfigFile {
@@ -120,5 +124,16 @@ impl WorkerConfig {
         if c.signup_secret.is_some() {
             self.signup_secret = c.signup_secret;
         }
+    }
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct ScheduleConfig {
+    retry_delay_base: Option<i64>,
+}
+
+impl ScheduleConfig {
+    pub fn retry_delay_base(&self) -> i64 {
+        self.retry_delay_base.unwrap_or(DEFAULT_RETRY_DELAY_BASE)
     }
 }

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -78,12 +78,14 @@ impl ConfigFile {
             }
         }
         self.worker.update(c.worker);
+        self.schedule.update(c.schedule);
     }
 }
 
 #[derive(Debug, Default, Deserialize)]
 pub struct HttpConfig {
     pub bind_addr: Option<String>,
+    pub real_ip_header: Option<String>,
     pub endpoint: Option<String>,
 }
 
@@ -91,6 +93,9 @@ impl HttpConfig {
     pub fn update(&mut self, c: HttpConfig) {
         if c.bind_addr.is_some() {
             self.bind_addr = c.bind_addr;
+        }
+        if c.real_ip_header.is_some() {
+            self.real_ip_header = c.real_ip_header;
         }
         if c.endpoint.is_some() {
             self.endpoint = c.endpoint;
@@ -133,6 +138,12 @@ pub struct ScheduleConfig {
 }
 
 impl ScheduleConfig {
+    pub fn update(&mut self, c: ScheduleConfig) {
+        if c.retry_delay_base.is_some() {
+            self.retry_delay_base = c.retry_delay_base;
+        }
+    }
+
     pub fn retry_delay_base(&self) -> i64 {
         self.retry_delay_base.unwrap_or(DEFAULT_RETRY_DELAY_BASE)
     }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,5 +1,6 @@
 use crate::errors::*;
 use colored::*;
+use chrono::NaiveDateTime;
 use strum_macros::{EnumString, AsRefStr, Display};
 use serde::{Serialize, Deserialize};
 use std::ops::Deref;
@@ -28,6 +29,26 @@ pub struct PkgRelease {
     pub suite: String,
     pub architecture: String,
     pub url: String,
+    pub built_at: Option<NaiveDateTime>,
+    pub attestation: Option<String>,
+    pub next_retry: Option<NaiveDateTime>,
+}
+
+impl PkgRelease {
+    pub fn new(name: String, version: String, distro: Distro, suite: String, architecture: String, url: String) -> PkgRelease {
+        PkgRelease {
+            name,
+            version,
+            status: Status::Unknown,
+            distro: distro.to_string(),
+            suite,
+            architecture,
+            url,
+            built_at: None,
+            attestation: None,
+            next_retry: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]

--- a/contrib/confs/rebuilderd-worker.conf
+++ b/contrib/confs/rebuilderd-worker.conf
@@ -2,3 +2,5 @@
 endpoint = "http://127.0.0.1:8484"
 ## The server would either whitelist our key or require a signup secret
 #signup_secret = "your_signup_key"
+## use diffoscope to generate diffs (default: false)
+#gen_diffoscope = true

--- a/contrib/confs/rebuilderd.conf
+++ b/contrib/confs/rebuilderd.conf
@@ -2,6 +2,9 @@
 #[http]
 ## The address to bind to. This is 127.0.0.1:8484 by default.
 #bind_addr = "0.0.0.0:8484"
+## If you use a reverse proxy, use this header instead of the actual connecting ip.
+## Make sure the reverse proxy has filters in place to prevent spoofing issues.
+#real_ip_header = "X-Real-IP"
 ## Set a default endpoint for rebuildctl. This is especially useful for the sync timer.
 #endpoint = "http://127.0.0.1:8484"
 

--- a/contrib/confs/rebuilderd.conf
+++ b/contrib/confs/rebuilderd.conf
@@ -25,3 +25,13 @@
 ## If we want to spawn new workers dynamically we can configure a sign up secret below.
 ## Use `pwgen -1s 32` to generate one.
 #signup_secret = "INSECURE"
+
+#[schedule]
+## Configure the delay to automatically retry failed rebuilds in hours. The
+## default is 24h, this base is multiplied with the number of rebuilds, so the
+## first retry would happen after 24h, the second retry would happen 48h after the
+## first retry and the third retry would happen 72h after the second retry. There
+## is no upper limit of retries, if you can't afford frequent retries it's
+## recommended to set this to a high value like 168 (1 week) or higher.
+## Successful rebuilds are not retried.
+#retry_delay_base = 24

--- a/contrib/docs/rebuilderd.conf.5.scd
+++ b/contrib/docs/rebuilderd.conf.5.scd
@@ -52,6 +52,17 @@ _signup_secret=_
 	allowed to join. See the authentication section in *rebuilderd*(1) for
 	details.
 
+## [schedule]
+
+_retry_delay_base=_
+	Configure the delay to automatically retry failed rebuilds in hours. The
+	default is 24h, this base is multiplied with the number of rebuilds, so the
+	first retry would happen after 24h, the second retry would happen 48h after the
+	first retry and the third retry would happen 72h after the second retry. There
+	is no upper limit of retries, if you can't afford frequent retries it's
+	recommended to set this to a high value like 168 (1 week) or higher.
+	Successful rebuilds are not retried.
+
 # EXAMPLE
 
 ```
@@ -82,6 +93,16 @@ _signup_secret=_
 ## If we want to spawn new workers dynamically we can configure a sign up secret below.
 ## Use `pwgen -1s 32` to generate one.
 #signup_secret = "INSECURE"
+
+#[schedule]
+## Configure the delay to automatically retry failed rebuilds in hours. The
+## default is 24h, this base is multiplied with the number of rebuilds, so the
+## first retry would happen after 24h, the second retry would happen 48h after the
+## first retry and the third retry would happen 72h after the second retry. There
+## is no upper limit of retries, if you can't afford frequent retries it's
+## recommended to set this to a high value like 168 (1 week) or higher.
+## Successful rebuilds are not retried.
+#retry_delay_base = 24
 ```
 
 # SEE ALSO

--- a/contrib/docs/rebuilderd.conf.5.scd
+++ b/contrib/docs/rebuilderd.conf.5.scd
@@ -21,6 +21,11 @@ This file contains configuration for both rebuilderd and rebuildctl.
 _bind_addr=_
 	The address to bind to. This is 127.0.0.1:8484 by default.
 
+_real_ip_header=_
+	If you use a reverse proxy, use this header instead of the actual connecting ip.
+	Make sure the reverse proxy has filters in place to prevent spoofing issues.
+	There is no default value, but it's recommended to use "X-Real-IP".
+
 _endpoint=_
 	Set a default endpoint for rebuildctl. This is especially useful for the
 	sync timer. Defaults to *http://127.0.0.1:8484*.
@@ -70,6 +75,9 @@ _retry_delay_base=_
 #[http]
 ## The address to bind to. This is 127.0.0.1:8484 by default.
 #bind_addr = "0.0.0.0:8484"
+## If you use a reverse proxy, use this header instead of the actual connecting ip.
+## Make sure the reverse proxy has filters in place to prevent spoofing issues.
+#real_ip_header = "X-Real-IP"
 ## Set a default endpoint for rebuildctl. This is especially useful for the sync timer.
 #endpoint = "http://127.0.0.1:8484"
 

--- a/daemon/migrations/2020-05-27-160242_retries/down.sql
+++ b/daemon/migrations/2020-05-27-160242_retries/down.sql
@@ -1,0 +1,22 @@
+PRAGMA foreign_keys=off;
+
+CREATE TABLE _packages_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    name VARCHAR NOT NULL,
+    version VARCHAR NOT NULL,
+    status VARCHAR NOT NULL,
+    distro VARCHAR NOT NULL,
+    suite VARCHAR NOT NULL,
+    architecture VARCHAR NOT NULL,
+    url VARCHAR NOT NULL,
+    CONSTRAINT packages_unique UNIQUE (name, distro, suite, architecture)
+);
+
+INSERT INTO _packages_new (id, name, version, status, distro, suite, architecture, url)
+    SELECT id, name, version, status, distro, suite, architecture, url
+    FROM packages;
+
+DROP TABLE packages;
+ALTER TABLE _packages_new RENAME TO packages;
+
+PRAGMA foreign_keys=on;

--- a/daemon/migrations/2020-05-27-160242_retries/up.sql
+++ b/daemon/migrations/2020-05-27-160242_retries/up.sql
@@ -1,0 +1,29 @@
+PRAGMA foreign_keys=off;
+
+CREATE TABLE _packages_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    name VARCHAR NOT NULL,
+    version VARCHAR NOT NULL,
+    status VARCHAR NOT NULL,
+    distro VARCHAR NOT NULL,
+    suite VARCHAR NOT NULL,
+    architecture VARCHAR NOT NULL,
+    url VARCHAR NOT NULL,
+    built_at DATETIME,
+    attestation VARCHAR,
+    checksum VARCHAR,
+    retries INTEGER NOT NULL,
+    next_retry DATETIME,
+    CONSTRAINT packages_unique UNIQUE (name, distro, suite, architecture)
+);
+
+INSERT INTO _packages_new (id, name, version, status, distro, suite, architecture, url, retries)
+    SELECT id, name, version, status, distro, suite, architecture, url, 0
+    FROM packages;
+
+DROP TABLE packages;
+ALTER TABLE _packages_new RENAME TO packages;
+
+PRAGMA foreign_keys=on;
+
+UPDATE packages SET next_retry = datetime('now') WHERE status = 'BAD';

--- a/daemon/migrations/2020-05-27-190113_priorities/down.sql
+++ b/daemon/migrations/2020-05-27-190113_priorities/down.sql
@@ -1,0 +1,23 @@
+PRAGMA foreign_keys=off;
+
+CREATE TABLE _queue_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    package_id INTEGER NOT NULL,
+    version VARCHAR NOT NULL,
+    queued_at DATETIME NOT NULL,
+    worker_id INTEGER,
+    started_at DATETIME,
+    last_ping DATETIME,
+    FOREIGN KEY(package_id) REFERENCES packages(id) ON DELETE CASCADE,
+    FOREIGN KEY(worker_id) REFERENCES workers(id) ON DELETE SET NULL,
+    CONSTRAINT queue_unique UNIQUE (package_id, version)
+);
+
+INSERT INTO _queue_new (id, package_id, version, queued_at, worker_id, started_at, last_ping)
+    SELECT id, package_id, version, queued_at, worker_id, started_at, last_ping
+    FROM queue;
+
+DROP TABLE queue;
+ALTER TABLE _queue_new RENAME TO queue;
+
+PRAGMA foreign_keys=on;

--- a/daemon/migrations/2020-05-27-190113_priorities/up.sql
+++ b/daemon/migrations/2020-05-27-190113_priorities/up.sql
@@ -1,0 +1,24 @@
+PRAGMA foreign_keys=off;
+
+CREATE TABLE _queue_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    package_id INTEGER NOT NULL,
+    version VARCHAR NOT NULL,
+    priority INTEGER NOT NULL,
+    queued_at DATETIME NOT NULL,
+    worker_id INTEGER,
+    started_at DATETIME,
+    last_ping DATETIME,
+    FOREIGN KEY(package_id) REFERENCES packages(id) ON DELETE CASCADE,
+    FOREIGN KEY(worker_id) REFERENCES workers(id) ON DELETE SET NULL,
+    CONSTRAINT queue_unique UNIQUE (package_id, version)
+);
+
+INSERT INTO _queue_new (id, package_id, version, priority, queued_at, worker_id, started_at, last_ping)
+    SELECT id, package_id, version, 0, queued_at, worker_id, started_at, last_ping
+    FROM queue;
+
+DROP TABLE queue;
+ALTER TABLE _queue_new RENAME TO queue;
+
+PRAGMA foreign_keys=on;

--- a/daemon/src/api.rs
+++ b/daemon/src/api.rs
@@ -324,6 +324,9 @@ pub async fn report_build(
     let item = models::Queued::get_id(report.queue.id, connection.as_ref())?;
     let mut pkg = models::Package::get_id(item.package_id, connection.as_ref())?;
 
+    if report.rebuild.status != BuildStatus::Good {
+        pkg.schedule_retry(cfg.schedule.retry_delay_base());
+    }
     pkg.update_status_safely(&report.rebuild, connection.as_ref())?;
     item.delete(connection.as_ref())?;
 

--- a/daemon/src/api.rs
+++ b/daemon/src/api.rs
@@ -134,9 +134,10 @@ fn get_worker_from_request(req: &HttpRequest, cfg: &Config, connection: &SqliteC
             .ok_or_else(|| format_err!("Can't determine client ip"))?;
         ci.ip()
     };
+    debug!("detected worker ip for {:?} as {}", key, ip);
 
     if let Some(mut worker) = models::Worker::get(key, connection)? {
-        worker.bump_last_ping();
+        worker.bump_last_ping(&ip);
         Ok(worker)
     } else {
         let worker = models::NewWorker::new(key.to_string(), ip, None);

--- a/daemon/src/api.rs
+++ b/daemon/src/api.rs
@@ -334,12 +334,10 @@ pub async fn report_build(
     let mut worker = get_worker_from_request(&req, connection.as_ref())?;
     let item = models::Queued::get_id(report.queue.id, connection.as_ref())?;
     let mut pkg = models::Package::get_id(item.package_id, connection.as_ref())?;
-    let status = match report.status {
-        BuildStatus::Good => Status::Good,
-        _ => Status::Bad,
-    };
-    pkg.update_status_safely(status, connection.as_ref())?;
+
+    pkg.update_status_safely(&report.rebuild, connection.as_ref())?;
     item.delete(connection.as_ref())?;
+
     worker.status = None;
     worker.update(connection.as_ref())?;
 

--- a/daemon/src/api.rs
+++ b/daemon/src/api.rs
@@ -1,6 +1,5 @@
 use actix_web::{get, post, web, HttpRequest, HttpResponse, Responder};
 use rebuilderd_common::errors::*;
-use rebuilderd_common::Status;
 use chrono::prelude::*;
 use crate::auth;
 use crate::config::Config;
@@ -94,17 +93,7 @@ pub async fn list_pkgs(
             continue;
         }
 
-        let status = pkg.status.parse::<Status>()?;
-
-        pkgs.push(PkgRelease {
-             name: pkg.name,
-             version: pkg.version,
-             status: status,
-             distro: pkg.distro,
-             suite: pkg.suite,
-             architecture: pkg.architecture,
-             url: pkg.url,
-        });
+        pkgs.push(pkg.into_api_item()?);
     }
 
     Ok(HttpResponse::Ok().json(pkgs))
@@ -281,7 +270,7 @@ pub async fn requeue_pkg(
         let reset = pkgs.into_iter()
             .map(|x| x.0)
             .collect::<Vec<_>>();
-        models::Package::reset_status_list(&reset, connection.as_ref())?;
+        models::Package::reset_status_for_requeued_list(&reset, connection.as_ref())?;
     }
 
     Ok(HttpResponse::Ok().json(()))

--- a/daemon/src/api.rs
+++ b/daemon/src/api.rs
@@ -158,7 +158,7 @@ pub async fn push_queue(
         debug!("found pkg: {:?}", pkg);
         let version = query.version.as_ref().unwrap_or(&pkg.version);
 
-        let item = models::NewQueued::new(pkg.id, version.to_string());
+        let item = models::NewQueued::new(pkg.id, version.to_string(), query.priority);
         debug!("adding to queue: {:?}", item);
         item.insert(connection.as_ref())?;
     }
@@ -262,7 +262,7 @@ pub async fn requeue_pkg(
     // TODO: use queue_batch after https://github.com/diesel-rs/diesel/pull/1884 is released
     // models::Queued::queue_batch(&pkgs, connection.as_ref())?;
     for (id, version) in &pkgs {
-        let q = models::NewQueued::new(*id, version.to_string());
+        let q = models::NewQueued::new(*id, version.to_string(), query.priority);
         q.insert(connection.as_ref()).ok();
     }
 

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -1,5 +1,5 @@
 use crate::auth;
-use rebuilderd_common::config::{ConfigFile, WorkerConfig};
+use rebuilderd_common::config::{ConfigFile, WorkerConfig, ScheduleConfig};
 use rebuilderd_common::errors::*;
 use std::env;
 use std::fs;
@@ -10,6 +10,7 @@ pub struct Config {
     pub auth_cookie: String,
     pub worker: WorkerConfig,
     pub bind_addr: String,
+    pub schedule: ScheduleConfig,
 }
 
 pub fn load(path: Option<&Path>) -> Result<Config> {
@@ -36,5 +37,6 @@ pub fn load(path: Option<&Path>) -> Result<Config> {
         auth_cookie,
         worker: config.worker,
         bind_addr,
+        schedule: config.schedule,
     })
 }

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -10,6 +10,7 @@ pub struct Config {
     pub auth_cookie: String,
     pub worker: WorkerConfig,
     pub bind_addr: String,
+    pub real_ip_header: Option<String>,
     pub schedule: ScheduleConfig,
 }
 
@@ -37,6 +38,7 @@ pub fn load(path: Option<&Path>) -> Result<Config> {
         auth_cookie,
         worker: config.worker,
         bind_addr,
+        real_ip_header: config.http.real_ip_header,
         schedule: config.schedule,
     })
 }

--- a/daemon/src/models/package.rs
+++ b/daemon/src/models/package.rs
@@ -1,5 +1,6 @@
 use crate::schema::*;
 use rebuilderd_common::Status;
+use rebuilderd_common::api::{Rebuild, BuildStatus};
 use rebuilderd_common::errors::*;
 use diesel::prelude::*;
 use rebuilderd_common::PkgRelease;
@@ -80,9 +81,12 @@ impl Package {
         Ok(())
     }
 
-    pub fn update_status_safely(&mut self, my_status: Status, connection: &SqliteConnection) -> Result<()> {
+    pub fn update_status_safely(&mut self, rebuild: &Rebuild, connection: &SqliteConnection) -> Result<()> {
         use crate::schema::packages::columns::*;
-        self.status = my_status.to_string();
+        self.status = match rebuild.status {
+            BuildStatus::Good => Status::Good.to_string(),
+            _ => Status::Bad.to_string(),
+        };
         diesel::update(packages::table
                 .filter(id.eq(self.id))
                 .filter(version.eq(&self.version))

--- a/daemon/src/models/package.rs
+++ b/daemon/src/models/package.rs
@@ -1,4 +1,5 @@
 use crate::schema::*;
+use chrono::{Utc, NaiveDateTime, Duration};
 use rebuilderd_common::Status;
 use rebuilderd_common::api::{Rebuild, BuildStatus};
 use rebuilderd_common::errors::*;
@@ -17,6 +18,11 @@ pub struct Package {
     pub suite: String,
     pub architecture: String,
     pub url: String,
+    pub built_at: Option<NaiveDateTime>,
+    pub attestation: Option<String>,
+    pub checksum: Option<String>,
+    pub retries: i32,
+    pub next_retry: Option<NaiveDateTime>,
 }
 
 impl Package {
@@ -72,6 +78,22 @@ impl Package {
         Ok(pkgs)
     }
 
+    pub fn list_distro_suite_architecture_due_retries(my_distro: &str, my_suite: &str, my_architecture: &str, connection: &SqliteConnection) -> Result<Vec<(i32, String)>> {
+        use crate::schema::packages::dsl::*;
+        use crate::schema::queue;
+        let pkgs = packages
+            .select((id, version))
+            .filter(distro.eq(my_distro))
+            .filter(suite.eq(my_suite))
+            .filter(architecture.eq(my_architecture))
+            .filter(next_retry.le(Utc::now().naive_utc()))
+            .left_outer_join(queue::table.on(id.eq(queue::package_id)))
+            .filter(queue::id.is_null())
+            .load(connection)?;
+        Ok(pkgs)
+    }
+
+    /*
     // when updating the verify status, use a custom query that enforces a version match
     pub fn update(&self, connection: &SqliteConnection) -> Result<()> {
         use crate::schema::packages::columns::*;
@@ -80,13 +102,39 @@ impl Package {
             .execute(connection)?;
         Ok(())
     }
+    */
+
+    pub fn bump_version(&self, connection: &SqliteConnection) -> Result<()> {
+        use crate::schema::packages::columns::*;
+        diesel::update(packages::table.filter(id.eq(self.id)))
+            .set((
+                version.eq(&self.version),
+                url.eq(&self.url),
+                status.eq("UNKWN"),
+                built_at.eq(Option::<NaiveDateTime>::None),
+                retries.eq(0),
+            ))
+            .execute(connection)?;
+        Ok(())
+    }
 
     pub fn update_status_safely(&mut self, rebuild: &Rebuild, connection: &SqliteConnection) -> Result<()> {
         use crate::schema::packages::columns::*;
+
+        if self.status == *Status::Bad {
+            self.retries += 1;
+        }
+
         self.status = match rebuild.status {
             BuildStatus::Good => Status::Good.to_string(),
-            _ => Status::Bad.to_string(),
+            _ => {
+                let delay = Duration::days(self.retries as i64 + 1);
+                self.next_retry = Some((Utc::now() + delay).naive_utc());
+                Status::Bad.to_string()
+            },
         };
+        self.built_at = Some(Utc::now().naive_utc());
+
         diesel::update(packages::table
                 .filter(id.eq(self.id))
                 .filter(version.eq(&self.version))
@@ -96,7 +144,7 @@ impl Package {
         Ok(())
     }
 
-    pub fn reset_status_list(pkgs: &[i32], connection: &SqliteConnection) -> Result<()> {
+    pub fn reset_status_for_requeued_list(pkgs: &[i32], connection: &SqliteConnection) -> Result<()> {
         use crate::schema::packages::columns::*;
         diesel::update(packages::table
                 .filter(id.eq_any(pkgs))
@@ -122,6 +170,9 @@ impl Package {
             status: self.status.parse()?,
             suite: self.suite,
             url: self.url,
+            built_at: self.built_at,
+            attestation: self.attestation,
+            next_retry: self.next_retry,
         })
     }
 }
@@ -136,6 +187,11 @@ pub struct NewPackage {
     pub suite: String,
     pub architecture: String,
     pub url: String,
+    pub built_at: Option<NaiveDateTime>,
+    pub attestation: Option<String>,
+    pub checksum: Option<String>,
+    pub retries: i32,
+    pub next_retry: Option<NaiveDateTime>,
 }
 
 impl NewPackage {
@@ -162,6 +218,11 @@ impl NewPackage {
             suite: pkg.suite,
             architecture: pkg.architecture,
             url: pkg.url,
+            built_at: None,
+            attestation: None,
+            checksum: None,
+            retries: 0,
+            next_retry: None,
         }
     }
 }

--- a/daemon/src/models/worker.rs
+++ b/daemon/src/models/worker.rs
@@ -51,7 +51,8 @@ impl Worker {
         Ok(())
     }
 
-    pub fn bump_last_ping(&mut self) {
+    pub fn bump_last_ping(&mut self, addr: &IpAddr) {
+        self.addr = addr.to_string();
         let now = Utc::now().naive_utc();
         self.last_ping = now;
         self.online = true;

--- a/daemon/src/schema.rs
+++ b/daemon/src/schema.rs
@@ -21,6 +21,7 @@ table! {
         id -> Integer,
         package_id -> Integer,
         version -> Text,
+        priority -> Integer,
         queued_at -> Timestamp,
         worker_id -> Nullable<Integer>,
         started_at -> Nullable<Timestamp>,

--- a/daemon/src/schema.rs
+++ b/daemon/src/schema.rs
@@ -8,6 +8,11 @@ table! {
         suite -> Text,
         architecture -> Text,
         url -> Text,
+        built_at -> Nullable<Timestamp>,
+        attestation -> Nullable<Text>,
+        checksum -> Nullable<Text>,
+        retries -> Integer,
+        next_retry -> Nullable<Timestamp>,
     }
 }
 

--- a/daemon/src/sync.rs
+++ b/daemon/src/sync.rs
@@ -88,7 +88,7 @@ fn sync(import: &mut SuiteImport, connection: &SqliteConnection) -> Result<()> {
     // TODO: check if queueing has been disabled in the request, eg. to initially fill the database
     for pkgs in queue.chunks(1_000) {
         debug!("queue: {:?}", pkgs.len());
-        models::Queued::queue_batch(pkgs, connection)?;
+        models::Queued::queue_batch(pkgs, 1, connection)?;
     }
     info!("successfully updated state");
 
@@ -102,7 +102,7 @@ fn retry(import: &SuiteImport, connection: &SqliteConnection) -> Result<()> {
     info!("queueing new jobs");
     for pkgs in queue.chunks(1_000) {
         debug!("queue: {:?}", pkgs.len());
-        models::Queued::queue_batch(pkgs, connection)?;
+        models::Queued::queue_batch(pkgs, 2, connection)?;
     }
     info!("successfully triggered {} retries", queue.len());
 

--- a/daemon/src/versions.rs
+++ b/daemon/src/versions.rs
@@ -1,5 +1,5 @@
 use rebuilderd_common::errors::*;
-use rebuilderd_common::{Distro, Status};
+use rebuilderd_common::Distro;
 use std::process::Command;
 use crate::models;
 use rebuilderd_common::PkgRelease;
@@ -62,8 +62,6 @@ impl PkgVerCmp for models::Package {
     }
 
     fn apply_fields(&mut self, new: &PkgRelease) {
-        // TODO: make sure we updated all fields necessary
-        self.status = Status::Unknown.to_string();
         self.version = new.version.clone();
         self.url = new.url.clone();
     }
@@ -75,8 +73,6 @@ impl PkgVerCmp for PkgRelease {
     }
 
     fn apply_fields(&mut self, new: &PkgRelease) {
-        // TODO: make sure we updated all fields necessary
-        self.status = Status::Unknown;
         self.version = new.version.clone();
         self.url = new.url.clone();
     }

--- a/tools/src/args.rs
+++ b/tools/src/args.rs
@@ -89,6 +89,8 @@ pub struct PkgsRequeue {
     pub name: Option<String>,
     #[structopt(long, possible_values=&["GOOD", "BAD", "UNKWN"])]
     pub status: Option<Status>,
+    #[structopt(long, default_value="0")]
+    pub priority: i32,
     #[structopt(long)]
     pub distro: Option<String>,
     #[structopt(long)]
@@ -119,11 +121,14 @@ pub struct QueueList {
 pub struct QueuePush {
     pub distro: String,
     pub suite: String,
-    #[structopt(long)]
-    pub architecture: Option<String>,
 
     pub name: String,
     pub version: Option<String>,
+
+    #[structopt(long)]
+    pub architecture: Option<String>,
+    #[structopt(long, default_value="0")]
+    pub priority: i32,
 }
 
 #[derive(Debug, StructOpt)]

--- a/tools/src/main.rs
+++ b/tools/src/main.rs
@@ -127,6 +127,7 @@ fn run(args: Args) -> Result<()> {
             client.with_auth_cookie()?.requeue_pkgs(&RequeueQuery {
                 name: args.name,
                 status: args.status,
+                priority: args.priority,
                 distro: args.distro,
                 suite: args.suite,
                 architecture: args.architecture,
@@ -182,6 +183,7 @@ fn run(args: Args) -> Result<()> {
             client.with_auth_cookie()?.push_queue(&PushQueue {
                 name: push.name,
                 version: push.version,
+                priority: push.priority,
                 distro: push.distro,
                 suite: push.suite,
                 architecture: push.architecture,

--- a/tools/src/schedule/archlinux.rs
+++ b/tools/src/schedule/archlinux.rs
@@ -2,7 +2,7 @@ use crate::schedule::{Pkg, fetch_url_or_path};
 use crate::PkgsSync;
 use flate2::read::GzDecoder;
 use nom::bytes::complete::take_till;
-use rebuilderd_common::{PkgRelease, Distro, Status};
+use rebuilderd_common::{PkgRelease, Distro};
 use rebuilderd_common::errors::*;
 use std::convert::TryInto;
 use std::io::prelude::*;
@@ -147,15 +147,14 @@ pub fn sync(sync: &PkgsSync) -> Result<Vec<PkgRelease>> {
         }
 
         let url = mirror_to_url(&source, &sync.suite, &sync.architecture, &pkg.filename)?;
-        pkgs.push(PkgRelease {
-            name: pkg.name,
-            version: pkg.version,
-            status: Status::Unknown,
-            distro: Distro::Archlinux.to_string(),
-            suite: sync.suite.to_string(),
-            architecture: pkg.architecture,
+        pkgs.push(PkgRelease::new(
+            pkg.name,
+            pkg.version,
+            Distro::Archlinux,
+            sync.suite.to_string(),
+            pkg.architecture,
             url,
-        });
+        ));
     }
 
     Ok(pkgs)

--- a/tools/src/schedule/debian.rs
+++ b/tools/src/schedule/debian.rs
@@ -1,7 +1,7 @@
 use crate::schedule::{Pkg, fetch_url_or_path};
 use crate::PkgsSync;
 use lzma::LzmaReader;
-use rebuilderd_common::{PkgRelease, Distro, Status};
+use rebuilderd_common::{PkgRelease, Distro};
 use rebuilderd_common::errors::*;
 use std::convert::TryInto;
 use std::io::BufReader;
@@ -156,15 +156,14 @@ pub fn sync(sync: &PkgsSync) -> Result<Vec<PkgRelease>> {
                     pkg.version,
                     arch);
 
-                pkgs.push(PkgRelease {
-                    name: bin.to_string(),
-                    version: pkg.version.to_string(),
-                    status: Status::Unknown,
-                    distro: Distro::Debian.to_string(),
-                    suite: sync.suite.to_string(),
-                    architecture: arch,
+                pkgs.push(PkgRelease::new(
+                    bin.to_string(),
+                    pkg.version.to_string(),
+                    Distro::Debian,
+                    sync.suite.to_string(),
+                    arch,
                     url,
-                });
+                ));
             }
         }
     }

--- a/worker/src/config.rs
+++ b/worker/src/config.rs
@@ -7,6 +7,8 @@ use std::path::Path;
 pub struct ConfigFile {
     pub endpoint: Option<String>,
     pub signup_secret: Option<String>,
+    #[serde(default)]
+    pub gen_diffoscope: bool,
 }
 
 pub fn load(path: Option<&Path>) -> Result<ConfigFile> {


### PR DESCRIPTION
We shouldn't give up on a package forever if it didn't work out the first time. This change re-adds failed rebuilds with low priority back into the queue with an increasing delay.