### PR TITLE
Refactor child process managment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,16 +385,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
-name = "base64-serde"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e964e3e0a930303c7c0bdb28ebf691dd98d9eee4b8b68019d2c995710b58a18"
-dependencies = [
- "base64",
- "serde",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,8 +1778,6 @@ name = "rebuilderd-common"
 version = "0.7.0"
 dependencies = [
  "anyhow",
- "base64",
- "base64-serde",
  "chrono",
  "colored",
  "dirs-next",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -20,6 +20,4 @@ chrono = { version = "0.4", features=["serde"] }
 colored = "2"
 dirs-next = "2"
 toml = "0.5.6"
-base64-serde = "0.6.1"
-base64 = "0.13"
 tokio-compat-02 = "0.1.2"

--- a/common/src/api.rs
+++ b/common/src/api.rs
@@ -310,20 +310,15 @@ pub enum BuildStatus {
     Fail,
 }
 
-use base64_serde::base64_serde_type;
-use base64::STANDARD;
-base64_serde_type!(Base64Standard, STANDARD);
-
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Rebuild {
     pub status: BuildStatus,
-    #[serde(with="Base64Standard")]
-    pub log: Vec<u8>,
+    pub log: String,
     pub diffoscope: Option<String>,
 }
 
 impl Rebuild {
-    pub fn new(status: BuildStatus, log: Vec<u8>) -> Rebuild {
+    pub fn new(status: BuildStatus, log: String) -> Rebuild {
         Rebuild {
             status,
             log,

--- a/contrib/docs/rebuilderd-worker.conf.5.scd
+++ b/contrib/docs/rebuilderd-worker.conf.5.scd
@@ -22,6 +22,16 @@ _endpoint=_
 _signup_secret=_
 	The server would either allowlist our key or require a signup secret.
 
+## [build]
+
+_timeout=_
+	Set a timeout in seconds after which diffoscope is terminated (defaults to 24 hours).
+
+_max_bytes=_
+	Set a maximum diffoscope output limit in bytes (default: none).
+	When reaching this limit the log is truncated but the rebuilder backend is
+	*not* terminated.
+
 ## [diffoscope]
 
 _enabled=_
@@ -31,11 +41,11 @@ _args=_
 	Pass additional arguments to diffoscope. Use wisely, some options might not work well.
 
 _timeout=_
-	Set a timeout in seconds after which diffoscope is terminated (default: 3600).
+	Set a timeout in seconds after which diffoscope is terminated (defaults to 1 hour).
 
 _max_bytes=_
 	Set a maximum diffoscope output limit in bytes (default: none).
-	When reaching this limit, diffoscope is terminated and the output is truncated.
+	When reaching this limit diffoscope is terminated and the output is truncated.
 
 # EXAMPLE
 
@@ -45,6 +55,12 @@ endpoint = "http://127.0.0.1:8484"
 ## The server would either allowlist our key or require a signup secret
 #signup_secret = "your_signup_key"
 
+[build]
+#timeout = 86400 # 24 hours
+## Set a maximum build log limit in bytes (default: none).
+## When reaching this limit the log is truncated but the rebuilder backend is *not* terminated.
+max_bytes = 10485760 # 10 MiB
+
 [diffoscope]
 ## Generate and attach diffs with diffoscope when rebuilding
 enabled = false
@@ -53,7 +69,7 @@ enabled = false
 ## Set a timeout in seconds after which diffoscope is terminated (default: 3600)
 #timeout = 600 # 10 minutes
 ## Set a maximum diffoscope output limit in bytes (default: none).
-## When reaching this limit, diffoscope is terminated and the output is truncated.
+## When reaching this limit diffoscope is terminated and the output is truncated.
 max_bytes = 41943040 # 40 MiB
 ```
 

--- a/daemon/src/models/build.rs
+++ b/daemon/src/models/build.rs
@@ -52,7 +52,7 @@ impl NewBuild {
     pub fn from_api(report: &BuildReport) -> NewBuild {
         NewBuild {
             diffoscope: report.rebuild.diffoscope.clone(),
-            build_log: report.rebuild.log.clone(),
+            build_log: report.rebuild.log.as_bytes().to_vec(),
         }
     }
 }

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -196,7 +196,7 @@ async fn main() -> Result<()> {
         };
         let rebuild = Rebuild {
             diffoscope: None,
-            log: Vec::new(),
+            log: String::new(),
             status: BuildStatus::Bad,
         };
         let report = BuildReport {
@@ -273,7 +273,7 @@ async fn main() -> Result<()> {
         };
         let rebuild = Rebuild {
             diffoscope: None,
-            log: Vec::new(),
+            log: String::new(),
             status: BuildStatus::Good,
         };
         let report = BuildReport {

--- a/worker/rebuilder-archlinux.sh
+++ b/worker/rebuilder-archlinux.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -xe
-repro -- "${2}"
+repro -- "${1}"

--- a/worker/rebuilder-archlinux.sh
+++ b/worker/rebuilder-archlinux.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -xe
-timeout 1d repro -- "${2}"
+repro -- "${2}"

--- a/worker/src/config.rs
+++ b/worker/src/config.rs
@@ -11,7 +11,15 @@ pub struct ConfigFile {
     #[serde(default)]
     pub gen_diffoscope: bool,
     #[serde(default)]
+    pub build: Build,
+    #[serde(default)]
     pub diffoscope: Diffoscope,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct Build {
+    pub timeout: Option<u64>,
+    pub max_bytes: Option<usize>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/worker/src/diffoscope.rs
+++ b/worker/src/diffoscope.rs
@@ -1,140 +1,23 @@
 use crate::config;
-use futures_util::FutureExt;
-use nix::unistd::Pid;
-use nix::sys::signal::{self, Signal};
+use crate::proc;
 use rebuilderd_common::errors::*;
-use std::process::Stdio;
-use std::time::{Duration, Instant};
-use tokio::io::AsyncReadExt;
-use tokio::process::{Command, Child};
-use tokio::select;
-use tokio::time;
-
-const SIGKILL_DELAY: u64 = 10;
-
-pub struct Capture {
-    output: Vec<u8>,
-    timeout: Duration,
-    limit: Option<usize>,
-    start: Instant,
-    closed: Option<Instant>,
-}
-
-impl Capture {
-    fn new(timeout: Duration, limit: Option<usize>) -> Capture {
-        let start = Instant::now();
-        Capture {
-            output: Vec::new(),
-            timeout,
-            limit,
-            start,
-            closed: None,
-        }
-    }
-
-    #[inline]
-    fn into_output(self) -> Vec<u8> {
-        self.output
-    }
-
-    async fn push_bytes(&mut self, child: &mut Child, slice: &[u8]) -> Result<()> {
-        if let Some(limit) = &self.limit {
-            if self.output.len() + slice.len() > *limit {
-                if self.closed.is_none() {
-                    warn!("Exceeding output limit: output={}, slice={}, limit={}", self.output.len(), slice.len(), limit);
-                    self.truncate(child, "TRUNCATED DUE TO SIZE LIMIT").await?;
-                }
-                return Ok(());
-            }
-        }
-
-        self.output.extend(slice);
-        Ok(())
-    }
-
-    async fn truncate(&mut self, child: &mut Child, reason: &str) -> Result<()> {
-        if let Some(pid) = child.id() {
-            info!("Sending SIGTERM to diffoscope(pid={})", pid);
-            signal::kill(Pid::from_raw(pid as i32), Signal::SIGTERM)?;
-        }
-
-        self.output.extend(format!("\n\n{}\n", reason).as_bytes());
-        self.closed = Some(Instant::now());
-        Ok(())
-    }
-
-    async fn next_wakeup(&mut self, child: &mut Child) -> Result<Duration> {
-        // check if we need to SIGKILL
-        if let Some(closed) = self.closed {
-            if closed.elapsed() > Duration::from_secs(SIGKILL_DELAY) {
-                if let Some(pid) = child.id() {
-                    warn!("diffoscope(pid={}) didn't terminate {}s after SIGTERM, sending SIGKILL", pid, SIGKILL_DELAY);
-                    // child.id is going to return None after this
-                    child.kill().await?;
-                }
-            }
-        }
-
-        // check if the process timed out and we need to SIGTERM
-        if let Some(remaining) = self.timeout.checked_sub(self.start.elapsed()) {
-            return Ok(remaining);
-        } else if self.closed.is_none() {
-            // the process has timed out, sending SIGTERM
-            warn!("diffoscope timed out, killing...");
-            self.truncate(child, "TRUNCATED DUE TO TIMEOUT").await?;
-        }
-
-        // if we don't need any timeouts anymore we just return any value
-        Ok(Duration::from_secs(SIGKILL_DELAY))
-    }
-}
+use std::path::Path;
+use std::time::Duration;
 
 pub async fn diffoscope(a: &str, b: &str, settings: &config::Diffoscope) -> Result<String> {
-    let mut args = settings.args.clone();
-    args.push("--".into());
-    args.push(a.into());
-    args.push(b.into());
-
-    info!("Running diffoscope {:?}", args);
-    let mut child = Command::new("diffoscope")
-        .args(&args)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    let mut child_stdout = child.stdout.take().unwrap();
-    let mut child_stderr = child.stderr.take().unwrap();
-
-    let mut buf_stdout = [0u8; 4096];
-    let mut buf_stderr = [0u8; 4096];
+    let mut args: Vec<&str> = settings.args.iter().map(AsRef::as_ref).collect();
+    args.push("--");
+    args.push(a);
+    args.push(b);
 
     let timeout = settings.timeout.unwrap_or(3600); // 1h
-    let timeout = Duration::from_secs(timeout);
 
-    let mut cap = Capture::new(timeout, settings.max_bytes);
-    let output = loop {
-        let remaining = cap.next_wakeup(&mut child).await?;
-
-        select! {
-            n = child_stdout.read(&mut buf_stdout).fuse() => {
-                let n = n?;
-                cap.push_bytes(&mut child, &buf_stdout[..n]).await?;
-            },
-            n = child_stderr.read(&mut buf_stderr).fuse() => {
-                let n = n?;
-                cap.push_bytes(&mut child, &buf_stderr[..n]).await?;
-            },
-            status = child.wait().fuse() => {
-                let status = status?;
-                let output = cap.into_output();
-                info!("diffoscope exited with exit={}, captured {} bytes", status, output.len());
-                break output;
-            }
-            _ = time::sleep(remaining).fuse() => continue,
-        }
+    let opts = proc::Options {
+        timeout: Duration::from_secs(timeout),
+        limit: settings.max_bytes,
+        kill_at_size_limit: true,
     };
-
-    let output = String::from_utf8_lossy(&output);
-    Ok(output.into_owned())
+    let bin = Path::new("diffoscope");
+    let (_success, output) = proc::run(bin, &args, opts).await?;
+    Ok(output)
 }

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -20,6 +20,7 @@ pub mod auth;
 pub mod config;
 pub mod diffoscope;
 pub mod download;
+pub mod proc;
 pub mod rebuild;
 pub mod setup;
 
@@ -111,7 +112,7 @@ async fn rebuild(client: &Client, config: &config::ConfigFile) -> Result<()> {
                 },
                 Err(err) => {
                     error!("Unexpected error while rebuilding package package: {:#}", err);
-                    Rebuild::new(BuildStatus::Fail, Vec::new())
+                    Rebuild::new(BuildStatus::Fail, String::new())
                 },
             };
             let report = BuildReport {

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -72,11 +72,13 @@ async fn spawn_rebuilder_script_with_heartbeat<'a>(client: &Client, distro: &Dis
     let input = item.package.url.to_string();
 
     let ctx = Context {
+        distro: &distro,
         script_location: None,
+        build: config.build.clone(),
         diffoscope: config.diffoscope.clone(),
     };
 
-    let mut rebuild = Box::pin(rebuild::rebuild(&distro, &ctx, &input));
+    let mut rebuild = Box::pin(rebuild::rebuild(&ctx, &input));
     loop {
         select! {
             res = &mut rebuild => {
@@ -187,8 +189,10 @@ async fn main() -> Result<()> {
                 diffoscope.enabled = true;
             }
 
-            let res = rebuild::rebuild(&build.distro, &Context {
+            let res = rebuild::rebuild(&Context {
+                distro: &build.distro,
                 script_location: build.script_location.as_ref(),
+                build: config::Build::default(),
                 diffoscope,
             }, &build.input).await?;
 

--- a/worker/src/proc.rs
+++ b/worker/src/proc.rs
@@ -1,0 +1,154 @@
+use futures_util::FutureExt;
+use nix::unistd::Pid;
+use nix::sys::signal::{self, Signal};
+use rebuilderd_common::errors::*;
+use std::path::Path;
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+use tokio::io::AsyncReadExt;
+use tokio::process::{Command, Child};
+use tokio::select;
+use tokio::time;
+
+const SIGKILL_DELAY: u64 = 10;
+
+pub struct Options {
+    pub timeout: Duration,
+    pub limit: Option<usize>,
+    pub kill_at_size_limit: bool,
+}
+
+pub struct Capture {
+    output: Vec<u8>,
+    timeout: Duration,
+    limit: Option<usize>,
+    kill_at_size_limit: bool,
+    start: Instant,
+    closed: Option<Instant>,
+}
+
+pub fn capture(opts: Options) -> Capture {
+    let start = Instant::now();
+    Capture {
+        output: Vec::new(),
+        timeout: opts.timeout,
+        limit: opts.limit,
+        kill_at_size_limit: opts.kill_at_size_limit,
+        start,
+        closed: None,
+    }
+}
+
+impl Capture {
+    pub fn new(opts: Options) -> Capture {
+        let start = Instant::now();
+        Capture {
+            output: Vec::new(),
+            timeout: opts.timeout,
+            limit: opts.limit,
+            kill_at_size_limit: opts.kill_at_size_limit,
+            start,
+            closed: None,
+        }
+    }
+
+    #[inline]
+    pub fn into_output(self) -> Vec<u8> {
+        self.output
+    }
+
+    pub async fn push_bytes(&mut self, child: &mut Child, slice: &[u8]) -> Result<()> {
+        if let Some(limit) = &self.limit {
+            if self.output.len() + slice.len() > *limit {
+                if self.closed.is_none() {
+                    warn!("Exceeding output limit: output={}, slice={}, limit={}", self.output.len(), slice.len(), limit);
+                    self.truncate(child, "TRUNCATED DUE TO SIZE LIMIT", self.kill_at_size_limit).await?;
+                }
+                return Ok(());
+            }
+        }
+
+        self.output.extend(slice);
+        Ok(())
+    }
+
+    async fn truncate(&mut self, child: &mut Child, reason: &str, kill: bool) -> Result<()> {
+        if kill {
+            if let Some(pid) = child.id() {
+                info!("Sending SIGTERM to child(pid={})", pid);
+                signal::kill(Pid::from_raw(pid as i32), Signal::SIGTERM)?;
+            }
+            self.closed = Some(Instant::now());
+        }
+
+        self.output.extend(format!("\n\n{}\n", reason).as_bytes());
+        Ok(())
+    }
+
+    pub async fn next_wakeup(&mut self, child: &mut Child) -> Result<Duration> {
+        // check if we need to SIGKILL due to SIGTERM timeout
+        if let Some(closed) = self.closed {
+            if closed.elapsed() > Duration::from_secs(SIGKILL_DELAY) {
+                if let Some(pid) = child.id() {
+                    warn!("child(pid={}) didn't terminate {}s after SIGTERM, sending SIGKILL", pid, SIGKILL_DELAY);
+                    // child.id is going to return None after this
+                    child.kill().await?;
+                }
+            }
+        }
+
+        // check if the process timed out and we need to SIGTERM
+        if let Some(remaining) = self.timeout.checked_sub(self.start.elapsed()) {
+            return Ok(remaining);
+        } else if self.closed.is_none() {
+            // the process has timed out, sending SIGTERM
+            warn!("child timed out, killing...");
+            self.truncate(child, "TRUNCATED DUE TO TIMEOUT", true).await?;
+        }
+
+        // if we don't need any timeouts anymore we just return any value
+        Ok(Duration::from_secs(SIGKILL_DELAY))
+    }
+}
+
+pub async fn run(bin: &Path, args: &[&str], opts: Options) -> Result<(bool, String)> {
+    info!("Running {:?} {:?}", bin, args);
+    let mut child = Command::new(bin)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let mut child_stdout = child.stdout.take().unwrap();
+    let mut child_stderr = child.stderr.take().unwrap();
+
+    let mut buf_stdout = [0u8; 4096];
+    let mut buf_stderr = [0u8; 4096];
+
+    let mut cap = capture(opts);
+    let (success, output) = loop {
+        let remaining = cap.next_wakeup(&mut child).await?;
+
+        select! {
+            n = child_stdout.read(&mut buf_stdout).fuse() => {
+                let n = n?;
+                cap.push_bytes(&mut child, &buf_stdout[..n]).await?;
+            },
+            n = child_stderr.read(&mut buf_stderr).fuse() => {
+                let n = n?;
+                cap.push_bytes(&mut child, &buf_stderr[..n]).await?;
+            },
+            status = child.wait().fuse() => {
+                let status = status?;
+                let output = cap.into_output();
+                info!("{:?} exited with exit={}, captured {} bytes", bin, status, output.len());
+                break (status.success(), output);
+            }
+            _ = time::sleep(remaining).fuse() => continue,
+        }
+    };
+
+    let output = String::from_utf8_lossy(&output);
+    Ok((success, output.into_owned()))
+}


### PR DESCRIPTION
- Allows configuring build log size limits
- Allows configuring build timeout instead of hardcoded 24h
- Reduces report post size by using lossy utf8 decoding instead of base64 encoded binary