### PR TITLE
Pkgbase import

### DIFF
--- a/common/src/api.rs
+++ b/common/src/api.rs
@@ -2,7 +2,7 @@ use crate::config::ConfigFile;
 use crate::errors::*;
 use chrono::prelude::*;
 use serde::{Serialize, Deserialize};
-use crate::{Distro, PkgRelease, Status};
+use crate::{Distro, PkgRelease, PkgGroup, Status};
 use crate::auth;
 use reqwest::{Client as HttpClient, RequestBuilder};
 use tokio_compat_02::FutureExt;
@@ -239,7 +239,7 @@ pub struct SuiteImport {
     pub distro: Distro,
     pub suite: String,
     pub architecture: String,
-    pub pkgs: Vec<PkgRelease>,
+    pub pkgs: Vec<PkgGroup>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -1,2 +1,2 @@
-pub use log::{debug, info, warn, error};
+pub use log::{trace, debug, info, warn, error};
 pub use anyhow::{Error, Context, Result, anyhow, format_err, bail};

--- a/contrib/confs/rebuilderd-sync.conf
+++ b/contrib/confs/rebuilderd-sync.conf
@@ -16,3 +16,10 @@ source = "https://ftp.halifax.rwth-aachen.de/archlinux/$repo/os/$arch"
 #maintainers = ["somebody"]
 #pkgs = ["some-pkg", "python-*"]
 #excludes = ["tensorflow*"]
+
+## TODO: we still need to figure out details
+[profile."debian-sid"]
+distro = "debian"
+suite = "main"
+architecture = "amd64"
+source = "http://deb.debian.org/debian"

--- a/daemon/migrations/2020-12-23-025138_pkgbase/down.sql
+++ b/daemon/migrations/2020-12-23-025138_pkgbase/down.sql
@@ -1,0 +1,31 @@
+PRAGMA foreign_keys=off;
+
+CREATE TABLE _packages_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    name VARCHAR NOT NULL,
+    version VARCHAR NOT NULL,
+    status VARCHAR NOT NULL,
+    distro VARCHAR NOT NULL,
+    suite VARCHAR NOT NULL,
+    architecture VARCHAR NOT NULL,
+    url VARCHAR NOT NULL,
+    build_id INTEGER,
+    built_at DATETIME,
+    attestation VARCHAR,
+    checksum VARCHAR,
+    retries INTEGER NOT NULL,
+    next_retry DATETIME,
+    CONSTRAINT packages_unique UNIQUE (name, distro, suite, architecture),
+    FOREIGN KEY(build_id) REFERENCES builds(id)
+);
+
+INSERT INTO _packages_new (id, name, version, status, distro, suite, architecture, url, build_id, built_at, attestation, checksum, retries, next_retry)
+    SELECT id, name, version, status, distro, suite, architecture, url, build_id, built_at, attestation, checksum, retries, next_retry
+    FROM packages;
+
+DROP TABLE packages;
+ALTER TABLE _packages_new RENAME TO packages;
+
+PRAGMA foreign_keys=on;
+
+DROP TABLE pkgbases;

--- a/daemon/migrations/2020-12-23-025138_pkgbase/up.sql
+++ b/daemon/migrations/2020-12-23-025138_pkgbase/up.sql
@@ -1,0 +1,43 @@
+CREATE TABLE pkgbases (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    name VARCHAR NOT NULL,
+    version VARCHAR NOT NULL,
+    distro VARCHAR NOT NULL,
+    suite VARCHAR NOT NULL,
+    architecture VARCHAR NOT NULL,
+    retries INTEGER NOT NULL,
+    next_retry DATETIME,
+    CONSTRAINT pkgbase_unique UNIQUE (name, version, distro, suite, architecture)
+);
+
+PRAGMA foreign_keys=off;
+
+CREATE TABLE _packages_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    base_id INTEGER,
+    name VARCHAR NOT NULL,
+    version VARCHAR NOT NULL,
+    status VARCHAR NOT NULL,
+    distro VARCHAR NOT NULL,
+    suite VARCHAR NOT NULL,
+    architecture VARCHAR NOT NULL,
+    url VARCHAR NOT NULL,
+    build_id INTEGER,
+    built_at DATETIME,
+    attestation VARCHAR,
+    checksum VARCHAR,
+    retries INTEGER NOT NULL,
+    next_retry DATETIME,
+    CONSTRAINT packages_unique UNIQUE (name, distro, suite, architecture),
+    FOREIGN KEY(base_id) REFERENCES pkgbases(id),
+    FOREIGN KEY(build_id) REFERENCES builds(id)
+);
+
+INSERT INTO _packages_new (id, base_id, name, version, status, distro, suite, architecture, url, build_id, built_at, attestation, checksum, retries, next_retry)
+    SELECT id, NULL, name, version, status, distro, suite, architecture, url, build_id, built_at, attestation, checksum, retries, next_retry
+    FROM packages;
+
+DROP TABLE packages;
+ALTER TABLE _packages_new RENAME TO packages;
+
+PRAGMA foreign_keys=on;

--- a/daemon/src/models/mod.rs
+++ b/daemon/src/models/mod.rs
@@ -7,5 +7,6 @@ macro_rules! import_models {
 
 import_models!(build);
 import_models!(package);
+import_models!(pkgbase);
 import_models!(worker);
 import_models!(queue);

--- a/daemon/src/models/pkgbase.rs
+++ b/daemon/src/models/pkgbase.rs
@@ -1,0 +1,97 @@
+use chrono::NaiveDateTime;
+use crate::schema::*;
+use diesel::prelude::*;
+use rebuilderd_common::errors::*;
+
+#[derive(Identifiable, Queryable, AsChangeset, Clone, PartialEq, Debug)]
+#[table_name="pkgbases"]
+pub struct PkgBase {
+    pub id: i32,
+    pub name: String,
+    pub version: String,
+    pub distro: String,
+    pub suite: String,
+    pub architecture: String,
+    pub retries: i32,
+    pub next_retry: Option<NaiveDateTime>,
+}
+
+impl PkgBase {
+    pub fn list_distro_suite_architecture(my_distro: &str, my_suite: &str, my_architecture: &str, connection: &SqliteConnection) -> Result<Vec<PkgBase>> {
+        use crate::schema::pkgbases::dsl::*;
+        let bases = pkgbases
+            .filter(distro.eq(my_distro))
+            .filter(suite.eq(my_suite))
+            .filter(architecture.eq(my_architecture))
+            .load::<PkgBase>(connection)?;
+        Ok(bases)
+    }
+
+    pub fn list_pkgs(&self, connection: &SqliteConnection) -> Result<Vec<i32>> {
+        use crate::schema::packages::dsl::*;
+        let pkgs = packages
+            .select(id)
+            .filter(base_id.eq(self.id))
+            .load(connection)?;
+        Ok(pkgs)
+    }
+
+    pub fn get_by(my_name: &str, my_distro: &str, my_suite: &str, my_architecture: Option<&str>, connection: &SqliteConnection) -> Result<Vec<PkgBase>> {
+        use crate::schema::pkgbases::dsl::*;
+        let mut query = pkgbases
+            .filter(name.eq(my_name))
+            .filter(distro.eq(my_distro))
+            .filter(suite.eq(my_suite))
+            .into_boxed();
+        if let Some(my_architecture) = my_architecture {
+            query = query.filter(architecture.eq(my_architecture));
+        }
+        let pkg = query.load::<PkgBase>(connection)?;
+        Ok(pkg)
+    }
+
+    /*
+    pub fn list_due_retries(my_distro: &str, my_suite: &str, my_architecture: &str, connection: &SqliteConnection) -> Result<Vec<(i32, String)>> {
+        use crate::schema::pkgbases::dsl::*;
+        use crate::schema::queue;
+        let pkgs = pkgbases
+            .select((id, version))
+            .filter(distro.eq(my_distro))
+            .filter(suite.eq(my_suite))
+            .filter(architecture.eq(my_architecture))
+            .filter(next_retry.le(Utc::now().naive_utc()))
+            .left_outer_join(queue::table.on(id.eq(queue::package_id)))
+            .filter(queue::id.is_null())
+            .load(connection)?;
+        Ok(pkgs)
+    }
+    */
+}
+
+#[derive(Insertable, PartialEq, Debug, Clone)]
+#[table_name="pkgbases"]
+pub struct NewPkgBase {
+    pub name: String,
+    pub version: String,
+    pub distro: String,
+    pub suite: String,
+    pub architecture: String,
+    pub retries: i32,
+    pub next_retry: Option<NaiveDateTime>,
+}
+
+impl NewPkgBase {
+    pub fn insert(&self, connection: &SqliteConnection) -> Result<()> {
+        diesel::insert_into(pkgbases::table)
+            .values(self)
+            .execute(connection)?;
+        Ok(())
+    }
+
+    pub fn insert_batch(pkgs: &[NewPkgBase], connection: &SqliteConnection) -> Result<()> {
+        diesel::insert_into(pkgbases::table)
+            .values(pkgs)
+            .execute(connection)?;
+        Ok(())
+    }
+}

--- a/daemon/src/models/pkgbase.rs
+++ b/daemon/src/models/pkgbase.rs
@@ -66,6 +66,13 @@ impl PkgBase {
         Ok(pkgs)
     }
     */
+
+    pub fn delete(my_id: i32, connection: &SqliteConnection) -> Result<()> {
+        use crate::schema::pkgbases::dsl::*;
+        diesel::delete(pkgbases.filter(id.eq(my_id)))
+            .execute(connection)?;
+        Ok(())
+    }
 }
 
 #[derive(Insertable, PartialEq, Debug, Clone)]

--- a/daemon/src/schema.rs
+++ b/daemon/src/schema.rs
@@ -9,6 +9,7 @@ table! {
 table! {
     packages (id) {
         id -> Integer,
+        base_id -> Nullable<Integer>,
         name -> Text,
         version -> Text,
         status -> Text,
@@ -20,6 +21,19 @@ table! {
         built_at -> Nullable<Timestamp>,
         attestation -> Nullable<Text>,
         checksum -> Nullable<Text>,
+        retries -> Integer,
+        next_retry -> Nullable<Timestamp>,
+    }
+}
+
+table! {
+    pkgbases (id) {
+        id -> Integer,
+        name -> Text,
+        version -> Text,
+        distro -> Text,
+        suite -> Text,
+        architecture -> Text,
         retries -> Integer,
         next_retry -> Nullable<Timestamp>,
     }
@@ -50,12 +64,14 @@ table! {
 }
 
 joinable!(packages -> builds (build_id));
+joinable!(packages -> pkgbases (base_id));
 joinable!(queue -> packages (package_id));
 joinable!(queue -> workers (worker_id));
 
 allow_tables_to_appear_in_same_query!(
     builds,
     packages,
+    pkgbases,
     queue,
     workers,
 );

--- a/daemon/src/versions.rs
+++ b/daemon/src/versions.rs
@@ -63,6 +63,7 @@ impl PkgVerCmp for models::Package {
 
     fn apply_fields(&mut self, new: &PkgRelease) {
         self.version = new.version.clone();
+        self.architecture = new.architecture.clone();
         self.url = new.url.clone();
     }
 }

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -3,7 +3,7 @@ use colored::Colorize;
 use env_logger::Env;
 use rebuilderd::config::Config;
 use rebuilderd_common::Distro;
-use rebuilderd_common::PkgRelease;
+use rebuilderd_common::{PkgGroup, PkgArtifact, PkgRelease};
 use rebuilderd_common::Status;
 use rebuilderd_common::api::*;
 use rebuilderd_common::config::*;
@@ -32,16 +32,21 @@ async fn initial_import(client: &Client) -> Result<()> {
     let distro = Distro::Archlinux;
     let suite = "core".to_string();
     let architecture = "x86_64".to_string();
-    let pkgs = vec![
-        PkgRelease::new(
-            "zstd".to_string(),
-            "1.4.5-1".to_string(),
-            Distro::Archlinux,
-            "core".to_string(),
-            "x86_64".to_string(),
-            "https://mirrors.kernel.org/archlinux/core/os/x86_64/zstd-1.4.5-1-x86_64.pkg.tar.zst".to_string(),
-        ),
-    ];
+
+    let url = "https://mirrors.kernel.org/archlinux/core/os/x86_64/zstd-1.4.5-1-x86_64.pkg.tar.zst".to_string();
+    let mut group = PkgGroup::new(
+        "pkgbase".to_string(),
+        "1.4.5-1".to_string(),
+        Distro::Archlinux,
+        suite.clone(),
+        architecture.clone(),
+        None,
+    );
+    group.add_artifact(PkgArtifact {
+        name: "zstd".to_string(),
+        url,
+    });
+    let pkgs = vec![group];
 
     client.sync_suite(&SuiteImport {
         distro,

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -31,4 +31,4 @@ toml = "0.5.6"
 dirs-next = "2"
 glob = "0.3.0"
 nom = "6"
-tokio = { version="0.3.2", features=["macros", "rt-multi-thread"] }
+tokio = { version="0.3.2", features=["macros", "rt-multi-thread", "io-std", "io-util"] }

--- a/tools/src/args.rs
+++ b/tools/src/args.rs
@@ -45,6 +45,8 @@ pub enum Pkgs {
     Ls(PkgsList),
     /// Sync package index with profile
     SyncProfile(PkgsSyncProfile),
+    /// Read a package sync from stdin
+    SyncStdin(PkgsSyncStdin),
     /// Requeue a given package
     Requeue(PkgsRequeue),
 }
@@ -56,6 +58,10 @@ pub struct PkgsSyncProfile {
     pub profile: String,
     #[structopt(long="sync-config", default_value="/etc/rebuilderd-sync.conf")]
     pub config_file: String,
+}
+
+#[derive(Debug, StructOpt)]
+pub struct PkgsSyncStdin {
 }
 
 #[derive(Debug, StructOpt)]

--- a/tools/src/args.rs
+++ b/tools/src/args.rs
@@ -74,6 +74,8 @@ pub struct PkgsSync {
     pub print_json: bool,
     #[structopt(long="maintainer")]
     pub maintainers: Vec<String>,
+    #[structopt(long="release")]
+    pub releases: Vec<String>,
     #[structopt(long="pkg")]
     pub pkgs: Vec<Pattern>,
     #[structopt(long="exclude")]

--- a/tools/src/config.rs
+++ b/tools/src/config.rs
@@ -25,6 +25,8 @@ impl SyncConfigFile {
 pub struct SyncProfile {
     pub distro: Distro,
     pub suite: String,
+    #[serde(default)]
+    pub releases: Vec<String>,
     pub architecture: String,
     pub source: String,
 

--- a/tools/src/main.rs
+++ b/tools/src/main.rs
@@ -107,6 +107,7 @@ async fn main() -> Result<()> {
             sync(client.with_auth_cookie()?, PkgsSync {
                 distro: profile.distro,
                 suite: profile.suite,
+                releases: profile.releases,
                 architecture: profile.architecture,
                 source: profile.source,
 

--- a/tools/src/main.rs
+++ b/tools/src/main.rs
@@ -11,6 +11,7 @@ use rebuilderd_common::Distro;
 use rebuilderd_common::api::*;
 use rebuilderd_common::errors::*;
 use rebuilderd_common::utils;
+use tokio::io::AsyncReadExt;
 use colored::*;
 
 pub mod args;
@@ -34,16 +35,16 @@ fn print_json<S: Serialize>(x: &S) -> Result<()> {
 }
 
 pub async fn sync(client: &Client, sync: PkgsSync) -> Result<()> {
-    let pkgs = match sync.distro {
+    let mut pkgs = match sync.distro {
         Distro::Archlinux => schedule::archlinux::sync(&sync)?,
         Distro::Debian => schedule::debian::sync(&sync)?,
     };
+    pkgs.sort_by(|a, b| a.base.cmp(&b.base));
 
     if sync.print_json {
         print_json(&pkgs)?;
     } else {
-        info!("Sending current suite to api...");
-        client.sync_suite(&SuiteImport {
+        sync_import(client, &SuiteImport {
             distro: sync.distro,
             suite: sync.suite,
             architecture: sync.architecture,
@@ -51,6 +52,13 @@ pub async fn sync(client: &Client, sync: PkgsSync) -> Result<()> {
         }).await?;
     }
 
+    Ok(())
+}
+
+pub async fn sync_import(client: &Client, sync: &SuiteImport) -> Result<()> {
+    info!("Sending current suite to api...");
+    client.sync_suite(sync).await
+        .context("Failed to send import to daemon")?;
     Ok(())
 }
 
@@ -107,6 +115,15 @@ async fn main() -> Result<()> {
                 pkgs: patterns_from(&profile.pkgs)?,
                 excludes: patterns_from(&profile.excludes)?,
             }).await?;
+        },
+        SubCommand::Pkgs(Pkgs::SyncStdin(_args)) => {
+            let mut stdin = tokio::io::stdin();
+            let mut buf = Vec::new();
+            stdin.read_to_end(&mut buf).await?;
+
+            let sync = serde_json::from_slice(&buf)
+                .context("Failed to deserialize pkg import from stdin")?;
+            sync_import(&client, &sync).await?;
         },
         SubCommand::Pkgs(Pkgs::Ls(ls)) => {
             let pkgs = client.list_pkgs(&ListPkgs {

--- a/tools/src/schedule/debian.rs
+++ b/tools/src/schedule/debian.rs
@@ -1,8 +1,9 @@
 use crate::args::PkgsSync;
 use crate::schedule::{Pkg, fetch_url_or_path};
 use lzma::LzmaReader;
-use rebuilderd_common::{PkgRelease, Distro};
+use rebuilderd_common::{PkgGroup, PkgArtifact, Distro};
 use rebuilderd_common::errors::*;
+use std::collections::HashMap;
 use std::convert::TryInto;
 use std::io::BufReader;
 use std::io::prelude::*;
@@ -16,7 +17,7 @@ pub fn any_architectures() -> Vec<String> {
 
 #[derive(Debug)]
 pub struct DebianPkg {
-    package: String,
+    base: String,
     binary: Vec<String>,
     version: String,
     directory: String,
@@ -25,6 +26,7 @@ pub struct DebianPkg {
 }
 
 impl DebianPkg {
+    // this is necessary because the buildinfo folder structure doesn't align with `Directory:` in Sources.xz
     fn buildinfo_path(&self) -> Result<String> {
         let idx = self.directory.find('/') .unwrap();
         let (_, directory) = self.directory.split_at(idx+1);
@@ -38,7 +40,7 @@ impl DebianPkg {
 
 impl Pkg for DebianPkg {
     fn pkg_name(&self) -> &str {
-        &self.package
+        &self.base
     }
 
     fn from_maintainer(&self, maintainers: &[String]) -> bool {
@@ -50,7 +52,7 @@ impl Pkg for DebianPkg {
 
 #[derive(Debug, Default)]
 pub struct NewPkg {
-    package: Option<String>,
+    base: Option<String>,
     binary: Option<Vec<String>>,
     version: Option<String>,
     directory: Option<String>,
@@ -65,7 +67,7 @@ impl TryInto<DebianPkg> for NewPkg {
 
     fn try_into(self: NewPkg) -> Result<DebianPkg> {
         Ok(DebianPkg {
-            package: self.package.ok_or_else(|| format_err!("Missing package field"))?,
+            base: self.base.ok_or_else(|| format_err!("Missing pkg base field"))?,
             binary: self.binary.ok_or_else(|| format_err!("Missing binary field"))?,
             version: self.version.ok_or_else(|| format_err!("Missing version field"))?,
             directory: self.directory.ok_or_else(|| format_err!("Missing directory field"))?,
@@ -92,7 +94,7 @@ pub fn extract_pkgs(bytes: &[u8]) -> Result<Vec<DebianPkg>> {
         if let Some(idx) = line.find(": ") {
             let (a, b) = line.split_at(idx);
             match a {
-                "Package" => pkg.package = Some(b[2..].to_string()),
+                "Package" => pkg.base = Some(b[2..].to_string()),
                 "Binary" => {
                     let mut binaries = Vec::new();
                     for binary in b[2..].split(", ") {
@@ -136,37 +138,53 @@ pub fn expand_architectures(arch: &str) -> Result<Vec<String>> {
     }
 }
 
-pub fn sync(sync: &PkgsSync) -> Result<Vec<PkgRelease>> {
+pub fn sync(sync: &PkgsSync) -> Result<Vec<PkgGroup>> {
     let client = reqwest::blocking::Client::new();
-    let bytes = fetch_url_or_path(&client, &sync.source)?;
+    // source looks like: `http://deb.debian.org/debian`
+    // should be transformed to eg: `http://deb.debian.org/debian/dists/sid/main/source/Sources.xz`
+    // TODO: figure out suite and release
+    // TODO: multiple releases could share rebuilds
+    let db_url = format!("{}/dists/sid/main/source/Sources.xz", sync.source);
+    let bytes = fetch_url_or_path(&client, &db_url)?;
 
     info!("Decompressing...");
-    let mut pkgs = Vec::new();
+    let mut bases: HashMap<_, PkgGroup> = HashMap::new();
     for pkg in extract_pkgs(&bytes)? {
         if !pkg.matches(&sync) {
             continue;
         }
 
         let directory = pkg.buildinfo_path()?;
-        for bin in &pkg.binary {
-            for arch in expand_architectures(&pkg.architecture)? {
-                let url = format!("https://buildinfos.debian.net/buildinfo-pool/{}/{}_{}_{}.buildinfo",
-                    directory,
-                    bin,
-                    pkg.version,
-                    arch);
+        for arch in expand_architectures(&pkg.architecture)? {
+            let url = format!("https://buildinfos.debian.net/buildinfo-pool/{}/{}_{}_{}.buildinfo",
+                directory,
+                pkg.base,
+                pkg.version,
+                arch);
 
-                pkgs.push(PkgRelease::new(
-                    bin.to_string(),
-                    pkg.version.to_string(),
-                    Distro::Debian,
-                    sync.suite.to_string(),
-                    arch,
-                    url,
-                ));
+            let mut group = PkgGroup::new(
+                pkg.base.clone(),
+                pkg.version.clone(),
+                Distro::Debian,
+                sync.suite.to_string(),
+                arch.clone(),
+                Some(url),
+            );
+            for bin in &pkg.binary {
+                group.add_artifact(PkgArtifact {
+                    name: bin.to_string(),
+                    url: format!("{}/{}/{}_{}_{}.deb",
+                        sync.source,
+                        pkg.directory,
+                        bin,
+                        pkg.version,
+                        arch,
+                    ),
+                });
             }
+            bases.insert(pkg.base.clone(), group);
         }
     }
 
-    Ok(pkgs)
+    Ok(bases.drain().map(|(_, v)| v).collect())
 }

--- a/tools/src/schedule/mod.rs
+++ b/tools/src/schedule/mod.rs
@@ -69,6 +69,7 @@ mod tests {
             suite: "community".to_string(),
             architecture: "x86_64".to_string(),
             source: "https://ftp.halifax.rwth-aachen.de/archlinux/$repo/os/$arch".to_string(),
+            releases: Vec::new(),
 
             print_json: false,
             maintainers: f.maintainers,

--- a/tools/src/schedule/mod.rs
+++ b/tools/src/schedule/mod.rs
@@ -80,6 +80,7 @@ mod tests {
     fn gen_pkg() -> ArchPkg {
         ArchPkg {
             name: "rebuilderd".to_string(),
+            base: "rebuilderd".to_string(),
             filename: "rebuilderd-0.2.1-1-x86_64.pkg.tar.zst".to_string(),
             version: "0.2.1-1".to_string(),
             architecture: "x86_64".to_string(),


### PR DESCRIPTION
This change prepares the database for a split package optimization so we only build the split package once and verify all outputs at once. This also makes Debian support easier to introduce.