### PR TITLE
Improve architecture handling and docs

### DIFF
--- a/common/src/api.rs
+++ b/common/src/api.rs
@@ -239,7 +239,6 @@ pub enum JobAssignment {
 pub struct SuiteImport {
     pub distro: Distro,
     pub suite: String,
-    pub architecture: String,
     pub pkgs: Vec<PkgGroup>,
 }
 

--- a/contrib/confs/rebuilderd-sync.conf
+++ b/contrib/confs/rebuilderd-sync.conf
@@ -1,25 +1,25 @@
-## rebuild all of core
+## rebuild all of archlinux core
 [profile."archlinux-core"]
 distro = "archlinux"
 suite = "core"
-architecture = "x86_64"
+architectures = ["x86_64"]
 source = "https://ftp.halifax.rwth-aachen.de/archlinux/$repo/os/$arch"
 
-## rebuild community packages of specific maintainers, or whitelist packages by name.
+## rebuild community packages of specific maintainers, or allow-list packages by name.
 ## If no filter is set, all packages are imported, if both filters are set the package only
 ## has to match one of them to be included.
 #[profile."archlinux-community"]
 #distro = "archlinux"
 #suite = "community"
-#architecture = "x86_64"
+#architectures = ["x86_64"]
 #source = "https://ftp.halifax.rwth-aachen.de/archlinux/$repo/os/$arch"
 #maintainers = ["somebody"]
 #pkgs = ["some-pkg", "python-*"]
 #excludes = ["tensorflow*"]
 
-## TODO: we still need to figure out details
-[profile."debian-sid"]
+[profile."debian-main"]
 distro = "debian"
 suite = "main"
-architecture = "amd64"
+architectures = ["amd64"]
+releases = ["buster", "sid"]
 source = "http://deb.debian.org/debian"

--- a/contrib/confs/rebuilderd.conf
+++ b/contrib/confs/rebuilderd.conf
@@ -23,7 +23,7 @@
 
 ## IMPORTANT: in production, make sure either `authorized_workers` or `signup_secret` is configured.
 #[worker]
-## If we have a fixed set of workers we can whitelist the keys here.
+## If we have a fixed set of workers we can allow-list the keys here.
 #authorized_workers = ["key1", "key2"]
 ## If we want to spawn new workers dynamically we can configure a sign up secret below.
 ## Use `pwgen -1s 32` to generate one.

--- a/contrib/docs/rebuildctl.1.scd
+++ b/contrib/docs/rebuildctl.1.scd
@@ -59,6 +59,15 @@ Sync a set of packages into rebuilderd and automatically queue them for
 verification. For an in-depth description of how the filters work you can look
 into *rebuilderd-sync.conf*(5).
 
+*--architecture <architecture>*
+	The architecture that should be imported (if needed). This option can be
+	specified multiple times. The specific values are distro specific, like
+	x86_64 for Arch Linux or amd64 for debian.
+
+*--release <release>*
+	The releases that should be imported (if needed). This option can be
+	specified multiple times.
+
 *--print-json*
 	Do a dry-run and only show what we would sync instead of actually sending
 	it to rebuilderd.
@@ -73,7 +82,7 @@ into *rebuilderd-sync.conf*(5).
 	Always ignore packages that match this pattern, even if it also matches one
 	of the other filters.
 
-*rebuildctl pkgs sync* archlinux community x86_64 \\++
+*rebuildctl pkgs sync* archlinux community --architecture x86_64 \\++
 \	'https://ftp.halifax.rwth-aachen.de/archlinux/$repo/os/$arch' \\++
 \	--maintainer kpcyrd --print-json
 

--- a/contrib/docs/rebuilderd-sync.conf.5.scd
+++ b/contrib/docs/rebuilderd-sync.conf.5.scd
@@ -23,8 +23,13 @@ _suite=_
 	This is for packages that have multiple suites/repositories, like *main*,
 	*contrib*, *non-free* or *core*, *extra* and *community*.
 
-_architecture=_
-	The architecture of the package list we want to import.
+_architectures=_
+	The architectures of the package list we want to import.
+
+_releases=_
+	Import specific releases. This option has no effect in rolling-release
+	distributions like Arch Linux but is important for eg. Debian. If the same
+	version is present in multiple releases the package is only imported once.
 
 _source=_
 	This is the url we want to import from. For Arch Linux this might look
@@ -69,7 +74,7 @@ suite = "core"
 architecture = "x86_64"
 source = "https://ftp.halifax.rwth-aachen.de/archlinux/$repo/os/$arch"
 
-## rebuild community packages of specific maintainers, or whitelist packages by name.
+## rebuild community packages of specific maintainers, or allow-list packages by name.
 ## If no filter is set, all packages are imported, if both filters are set the package only
 ## has to match one of them to be included.
 #[profile."archlinux-community"]

--- a/contrib/docs/rebuilderd.1.scd
+++ b/contrib/docs/rebuilderd.1.scd
@@ -41,7 +41,7 @@ find a pre-configured value we're going to generate one and write it to
 # WORKER AUTHENTICATION
 
 There are two ways to authenticate workers. If you work with a fixed number of
-workers you can whitelist their keys:
+workers you can allow-list their keys:
 
 ```
 [worker]

--- a/contrib/docs/rebuilderd.conf.5.scd
+++ b/contrib/docs/rebuilderd.conf.5.scd
@@ -96,7 +96,7 @@ _retry_delay_base=_
 
 ## IMPORTANT: in production, make sure either `authorized_workers` or `signup_secret` is configured.
 #[worker]
-## If we have a fixed set of workers we can whitelist the keys here.
+## If we have a fixed set of workers we can allow-list the keys here.
 #authorized_workers = ["key1", "key2"]
 ## If we want to spawn new workers dynamically we can configure a sign up secret below.
 ## Use `pwgen -1s 32` to generate one.

--- a/daemon/src/auth.rs
+++ b/daemon/src/auth.rs
@@ -34,7 +34,7 @@ pub fn worker(cfg: &Config, req: &HttpRequest) -> Result<()> {
         // TODO: we do not challenge the worker keys yet
         // Vec<String>::contains() is inefficient with &str
         if cfg.worker.authorized_workers.iter().any(|x| x == worker_key) {
-            debug!("worker authenticated by whitelisted key");
+            debug!("worker authenticated by allow-listed key");
             return Ok(());
         }
 

--- a/daemon/src/models/package.rs
+++ b/daemon/src/models/package.rs
@@ -69,24 +69,22 @@ impl Package {
         Ok(pkgs)
     }
 
-    pub fn list_distro_suite_architecture(my_distro: &str, my_suite: &str, my_architecture: &str, connection: &SqliteConnection) -> Result<Vec<Package>> {
+    pub fn list_distro_suite(my_distro: &str, my_suite: &str, connection: &SqliteConnection) -> Result<Vec<Package>> {
         use crate::schema::packages::dsl::*;
         let pkgs = packages
             .filter(distro.eq(my_distro))
             .filter(suite.eq(my_suite))
-            .filter(architecture.eq(my_architecture))
             .load::<Package>(connection)?;
         Ok(pkgs)
     }
 
-    pub fn list_distro_suite_architecture_due_retries(my_distro: &str, my_suite: &str, my_architecture: &str, connection: &SqliteConnection) -> Result<Vec<(i32, String)>> {
+    pub fn list_distro_suite_due_retries(my_distro: &str, my_suite: &str, connection: &SqliteConnection) -> Result<Vec<(i32, String)>> {
         use crate::schema::packages::dsl::*;
         use crate::schema::queue;
         let pkgs = packages
             .select((id, version))
             .filter(distro.eq(my_distro))
             .filter(suite.eq(my_suite))
-            .filter(architecture.eq(my_architecture))
             .filter(next_retry.le(Utc::now().naive_utc()))
             .left_outer_join(queue::table.on(id.eq(queue::package_id)))
             .filter(queue::id.is_null())

--- a/daemon/src/models/pkgbase.rs
+++ b/daemon/src/models/pkgbase.rs
@@ -17,12 +17,11 @@ pub struct PkgBase {
 }
 
 impl PkgBase {
-    pub fn list_distro_suite_architecture(my_distro: &str, my_suite: &str, my_architecture: &str, connection: &SqliteConnection) -> Result<Vec<PkgBase>> {
+    pub fn list_distro_suite(my_distro: &str, my_suite: &str, connection: &SqliteConnection) -> Result<Vec<PkgBase>> {
         use crate::schema::pkgbases::dsl::*;
         let bases = pkgbases
             .filter(distro.eq(my_distro))
             .filter(suite.eq(my_suite))
-            .filter(architecture.eq(my_architecture))
             .load::<PkgBase>(connection)?;
         Ok(bases)
     }
@@ -51,14 +50,13 @@ impl PkgBase {
     }
 
     /*
-    pub fn list_due_retries(my_distro: &str, my_suite: &str, my_architecture: &str, connection: &SqliteConnection) -> Result<Vec<(i32, String)>> {
+    pub fn list_due_retries(my_distro: &str, my_suite: &str, connection: &SqliteConnection) -> Result<Vec<(i32, String)>> {
         use crate::schema::pkgbases::dsl::*;
         use crate::schema::queue;
         let pkgs = pkgbases
             .select((id, version))
             .filter(distro.eq(my_distro))
             .filter(suite.eq(my_suite))
-            .filter(architecture.eq(my_architecture))
             .filter(next_retry.le(Utc::now().naive_utc()))
             .left_outer_join(queue::table.on(id.eq(queue::package_id)))
             .filter(queue::id.is_null())

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -51,7 +51,6 @@ async fn initial_import(client: &Client) -> Result<()> {
     client.sync_suite(&SuiteImport {
         distro,
         suite,
-        architecture,
         pkgs,
     }).await?;
 

--- a/tools/src/args.rs
+++ b/tools/src/args.rs
@@ -64,15 +64,15 @@ pub struct PkgsSyncProfile {
 pub struct PkgsSyncStdin {
     pub distro: Distro,
     pub suite: String,
-    pub architecture: String,
 }
 
 #[derive(Debug, StructOpt)]
 pub struct PkgsSync {
     pub distro: Distro,
     pub suite: String,
-    pub architecture: String,
     pub source: String,
+    #[structopt(long="arch")]
+    pub architectures: Vec<String>,
     #[structopt(long="print-json")]
     pub print_json: bool,
     #[structopt(long="maintainer")]

--- a/tools/src/args.rs
+++ b/tools/src/args.rs
@@ -71,7 +71,7 @@ pub struct PkgsSync {
     pub distro: Distro,
     pub suite: String,
     pub source: String,
-    #[structopt(long="arch")]
+    #[structopt(long="architecture")]
     pub architectures: Vec<String>,
     #[structopt(long="print-json")]
     pub print_json: bool,

--- a/tools/src/args.rs
+++ b/tools/src/args.rs
@@ -62,6 +62,9 @@ pub struct PkgsSyncProfile {
 
 #[derive(Debug, StructOpt)]
 pub struct PkgsSyncStdin {
+    pub distro: Distro,
+    pub suite: String,
+    pub architecture: String,
 }
 
 #[derive(Debug, StructOpt)]

--- a/tools/src/config.rs
+++ b/tools/src/config.rs
@@ -27,7 +27,9 @@ pub struct SyncProfile {
     pub suite: String,
     #[serde(default)]
     pub releases: Vec<String>,
-    pub architecture: String,
+    pub architecture: Option<String>,
+    #[serde(default)]
+    pub architectures: Vec<String>,
     pub source: String,
 
     #[serde(default)]

--- a/tools/src/main.rs
+++ b/tools/src/main.rs
@@ -117,14 +117,20 @@ async fn main() -> Result<()> {
                 excludes: patterns_from(&profile.excludes)?,
             }).await?;
         },
-        SubCommand::Pkgs(Pkgs::SyncStdin(_args)) => {
+        SubCommand::Pkgs(Pkgs::SyncStdin(sync)) => {
             let mut stdin = tokio::io::stdin();
             let mut buf = Vec::new();
             stdin.read_to_end(&mut buf).await?;
 
-            let sync = serde_json::from_slice(&buf)
+            let pkgs = serde_json::from_slice(&buf)
                 .context("Failed to deserialize pkg import from stdin")?;
-            sync_import(&client, &sync).await?;
+
+            sync_import(&client, &SuiteImport {
+                distro: sync.distro,
+                suite: sync.suite,
+                architecture: sync.architecture,
+                pkgs,
+            }).await?;
         },
         SubCommand::Pkgs(Pkgs::Ls(ls)) => {
             let pkgs = client.list_pkgs(&ListPkgs {

--- a/tools/src/main.rs
+++ b/tools/src/main.rs
@@ -47,7 +47,6 @@ pub async fn sync(client: &Client, sync: PkgsSync) -> Result<()> {
         sync_import(client, &SuiteImport {
             distro: sync.distro,
             suite: sync.suite,
-            architecture: sync.architecture,
             pkgs,
         }).await?;
     }
@@ -102,13 +101,20 @@ async fn main() -> Result<()> {
         SubCommand::Pkgs(Pkgs::Sync(args)) => sync(client.with_auth_cookie()?, args).await?,
         SubCommand::Pkgs(Pkgs::SyncProfile(args)) => {
             let mut config = SyncConfigFile::load(&args.config_file)?;
-            let profile = config.profiles.remove(&args.profile)
+            let mut profile = config.profiles.remove(&args.profile)
                 .ok_or_else(|| format_err!("Profile not found: {:?}", args.profile))?;
+
+            // TODO: remove this after we've deprecated architecture=
+            if let Some(arch) = profile.architecture {
+                warn!("Deprecated option in config: replace `architecture = \"{}\"` with `architectures = [\"{}\"]`", arch, arch);
+                profile.architectures.push(arch)
+            }
+
             sync(client.with_auth_cookie()?, PkgsSync {
                 distro: profile.distro,
                 suite: profile.suite,
                 releases: profile.releases,
-                architecture: profile.architecture,
+                architectures: profile.architectures,
                 source: profile.source,
 
                 print_json: args.print_json,
@@ -128,7 +134,6 @@ async fn main() -> Result<()> {
             sync_import(&client, &SuiteImport {
                 distro: sync.distro,
                 suite: sync.suite,
-                architecture: sync.architecture,
                 pkgs,
             }).await?;
         },

--- a/tools/src/schedule/mod.rs
+++ b/tools/src/schedule/mod.rs
@@ -160,7 +160,7 @@ mod tests {
     }
 
     #[test]
-    fn no_filter_but_blacklist_match() {
+    fn no_filter_but_excludes_match() {
         let m = gen_pkg().matches(&gen_filter(Filter {
             maintainers: Vec::new(),
             pkgs: Vec::new(),
@@ -170,7 +170,7 @@ mod tests {
     }
 
     #[test]
-    fn no_filter_and_no_blacklist_match() {
+    fn no_filter_and_no_excludes_match() {
         let m = gen_pkg().matches(&gen_filter(Filter {
             maintainers: Vec::new(),
             pkgs: Vec::new(),
@@ -180,7 +180,7 @@ mod tests {
     }
 
     #[test]
-    fn pkg_name_and_maintainer_match_and_no_blacklist_match() {
+    fn pkg_name_and_maintainer_match_and_no_excludes_match() {
         let m = gen_pkg().matches(&gen_filter(Filter {
             maintainers: vec!["kpcyrd <kpcyrd@archlinux.org>".to_string()],
             pkgs: vec!["rebuilderd".to_string()],
@@ -190,7 +190,7 @@ mod tests {
     }
 
     #[test]
-    fn pkg_name_and_maintainer_match_but_blacklist_match() {
+    fn pkg_name_and_maintainer_match_but_excludes_match() {
         let m = gen_pkg().matches(&gen_filter(Filter {
             maintainers: vec!["kpcyrd <kpcyrd@archlinux.org>".to_string()],
             pkgs: vec!["rebuilderd".to_string()],

--- a/tools/src/schedule/mod.rs
+++ b/tools/src/schedule/mod.rs
@@ -67,7 +67,7 @@ mod tests {
         PkgsSync {
             distro: Distro::Archlinux,
             suite: "community".to_string(),
-            architecture: "x86_64".to_string(),
+            architectures: vec!["x86_64".to_string()],
             source: "https://ftp.halifax.rwth-aachen.de/archlinux/$repo/os/$arch".to_string(),
             releases: Vec::new(),
 

--- a/worker/src/diffoscope.rs
+++ b/worker/src/diffoscope.rs
@@ -1,6 +1,7 @@
 use crate::config;
 use crate::proc;
 use rebuilderd_common::errors::*;
+use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;
 
@@ -17,6 +18,7 @@ pub async fn diffoscope(a: &str, b: &str, settings: &config::Diffoscope) -> Resu
         size_limit: settings.max_bytes,
         kill_at_size_limit: true,
         passthrough: false,
+        envs: HashMap::new(),
     };
     let bin = Path::new("diffoscope");
     let (_success, output) = proc::run(bin, &args, opts).await?;

--- a/worker/src/proc.rs
+++ b/worker/src/proc.rs
@@ -2,6 +2,7 @@ use futures_util::FutureExt;
 use nix::unistd::Pid;
 use nix::sys::signal::{self, Signal};
 use rebuilderd_common::errors::*;
+use std::collections::HashMap;
 use std::path::Path;
 use std::process::Stdio;
 use std::time::{Duration, Instant};
@@ -17,6 +18,7 @@ pub struct Options {
     pub size_limit: Option<usize>,
     pub kill_at_size_limit: bool,
     pub passthrough: bool,
+    pub envs: HashMap<String, String>,
 }
 
 pub struct Capture {
@@ -111,6 +113,7 @@ pub async fn run(bin: &Path, args: &[&str], opts: Options) -> Result<(bool, Stri
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .envs(&opts.envs)
         .spawn()?;
 
     let mut child_stdout = child.stdout.take().unwrap();
@@ -175,6 +178,7 @@ mod tests {
             size_limit: None,
             kill_at_size_limit: false,
             passthrough: false,
+            envs: HashMap::new(),
         }).await.unwrap();
         assert!(success);
         assert_eq!(output, "hello world\n");
@@ -191,6 +195,7 @@ mod tests {
             size_limit: Some(50),
             kill_at_size_limit: false,
             passthrough: false,
+            envs: HashMap::new(),
         }).await.unwrap();
         assert!(success);
         assert_eq!(output,
@@ -209,6 +214,7 @@ mod tests {
             size_limit: Some(50),
             kill_at_size_limit: true,
             passthrough: false,
+            envs: HashMap::new(),
         }).await.unwrap();
         assert!(!success);
         assert_eq!(output,
@@ -229,6 +235,7 @@ mod tests {
             size_limit: None,
             kill_at_size_limit: false,
             passthrough: false,
+            envs: HashMap::new(),
         }).await.unwrap();
         assert!(!success);
         assert_eq!(output,
@@ -249,6 +256,7 @@ mod tests {
             size_limit: Some(50),
             kill_at_size_limit: false,
             passthrough: false,
+            envs: HashMap::new(),
         }).await.unwrap();
         assert!(!success);
         assert_eq!(output,

--- a/worker/src/rebuild.rs
+++ b/worker/src/rebuild.rs
@@ -7,6 +7,7 @@ use rebuilderd_common::api::{Rebuild, BuildStatus};
 use rebuilderd_common::errors::*;
 use rebuilderd_common::errors::{Context as _};
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -92,11 +93,15 @@ async fn verify<'a>(ctx: &Context<'a>, path: &str) -> Result<(bool, String)> {
 
     let timeout = ctx.build.timeout.unwrap_or(3600 * 24); // 24h
 
+    let mut envs = HashMap::new();
+    envs.insert("REBUILDERD_OUTDIR".into(), "./build".into());
+
     let opts = proc::Options {
         timeout: Duration::from_secs(timeout),
         size_limit: ctx.build.max_bytes,
         kill_at_size_limit: false,
         passthrough: !ctx.build.silent,
+        envs,
     };
     proc::run(bin.as_ref(), args, opts).await
 }


### PR DESCRIPTION
We're deprecating the old `architecture = "x86_64"` option and replace it with `architectures = ["x86_64"]` so we can get rid of some bug-prone code for `any`/`all` packages. The old config is still valid but going to print a warning.