### PR TITLE
Convert blocking reqwest client to async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,9 +781,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
+checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -796,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
+checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -806,15 +806,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
+checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
+checksum = "4d0d535a57b87e1ae31437b892713aee90cd2d7b0ee48727cd11fc72ef54761c"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -823,15 +823,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
+checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
+checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
 dependencies = [
  "autocfg",
  "proc-macro-hack",
@@ -842,21 +842,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
+checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
 
 [[package]]
 name = "futures-task"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
+checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
+checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
 dependencies = [
  "autocfg",
  "futures-channel",
@@ -954,7 +954,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.8.2",
+ "tokio 1.9.0",
  "tokio-util 0.6.7",
  "tracing",
 ]
@@ -1052,7 +1052,7 @@ dependencies = [
  "itoa",
  "pin-project-lite 0.2.7",
  "socket2 0.4.0",
- "tokio 1.8.2",
+ "tokio 1.9.0",
  "tower-service",
  "tracing",
  "want",
@@ -1067,7 +1067,7 @@ dependencies = [
  "bytes 1.0.1",
  "hyper",
  "native-tls",
- "tokio 1.8.2",
+ "tokio 1.9.0",
  "tokio-native-tls",
 ]
 
@@ -1653,9 +1653,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -1792,7 +1792,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "tar",
- "tokio 1.8.2",
+ "tokio 1.9.0",
  "toml",
 ]
 
@@ -1842,7 +1842,7 @@ dependencies = [
  "rebuilderd-common",
  "structopt",
  "tempfile",
- "tokio 1.8.2",
+ "tokio 1.9.0",
 ]
 
 [[package]]
@@ -1860,7 +1860,7 @@ dependencies = [
  "sodiumoxide",
  "structopt",
  "tempfile",
- "tokio 1.8.2",
+ "tokio 1.9.0",
  "toml",
  "url",
 ]
@@ -1936,7 +1936,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.8.2",
+ "tokio 1.9.0",
  "tokio-native-tls",
  "url",
  "wasm-bindgen",
@@ -2486,9 +2486,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2602b8af3767c285202012822834005f596c811042315fa7e9f5b12b2a43207"
+checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
 dependencies = [
  "autocfg",
  "bytes 1.0.1",
@@ -2521,7 +2521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.8.2",
+ "tokio 1.9.0",
 ]
 
 [[package]]
@@ -2549,7 +2549,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.2.7",
- "tokio 1.8.2",
+ "tokio 1.9.0",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -110,12 +110,12 @@ cd daemon; cargo run
 
 Run a rebuild worker:
 ```
-cd worker; cargo run connect http://127.0.0.1:8484
+cd worker; cargo run -- connect http://127.0.0.1:8484
 ```
 
 Afterwards it's time to import some packages:
 ```
-cd tools; cargo run --release -- pkgs sync archlinux community \
+cd tools; cargo run -- pkgs sync archlinux community \
     'https://ftp.halifax.rwth-aachen.de/archlinux/$repo/os/$arch' \
     --architecture x86_64 --maintainer kpcyrd
 ```
@@ -124,12 +124,12 @@ The `--maintainer` option is optional and allows you to rebuild packages by a sp
 
 To show the current status of our imported packages run:
 ```
-cd tools; cargo run pkgs ls
+cd tools; cargo run -- pkgs ls
 ```
 
 To inspect the queue run:
 ```
-cd tools; cargo run queue ls
+cd tools; cargo run -- queue ls
 ```
 
 ## Dependencies

--- a/tools/src/main.rs
+++ b/tools/src/main.rs
@@ -37,8 +37,8 @@ fn print_json<S: Serialize>(x: &S) -> Result<()> {
 
 pub async fn sync(client: &Client, sync: PkgsSync) -> Result<()> {
     let mut pkgs = match sync.distro {
-        Distro::Archlinux => schedule::archlinux::sync(&sync)?,
-        Distro::Debian => schedule::debian::sync(&sync)?,
+        Distro::Archlinux => schedule::archlinux::sync(&sync).await?,
+        Distro::Debian => schedule::debian::sync(&sync).await?,
     };
     pkgs.sort_by(|a, b| a.base.cmp(&b.base));
 

--- a/tools/src/schedule/debian.rs
+++ b/tools/src/schedule/debian.rs
@@ -138,15 +138,16 @@ pub fn expand_architectures(arch: &str) -> Result<Vec<String>> {
     }
 }
 
-pub fn sync(sync: &PkgsSync) -> Result<Vec<PkgGroup>> {
-    let client = reqwest::blocking::Client::new();
+pub async fn sync(sync: &PkgsSync) -> Result<Vec<PkgGroup>> {
+    let client = reqwest::Client::new();
 
     let mut bases: HashMap<_, PkgGroup> = HashMap::new();
     for release in &sync.releases {
         // source looks like: `http://deb.debian.org/debian`
         // should be transformed to eg: `http://deb.debian.org/debian/dists/sid/main/source/Sources.xz`
         let db_url = format!("{}/dists/{}/{}/source/Sources.xz", sync.source, release, sync.suite);
-        let bytes = fetch_url_or_path(&client, &db_url)?;
+        let bytes = fetch_url_or_path(&client, &db_url)
+            .await?;
 
         info!("Decompressing...");
         for pkg in extract_pkgs(&bytes)? {

--- a/tools/src/schedule/mod.rs
+++ b/tools/src/schedule/mod.rs
@@ -1,15 +1,17 @@
 use crate::args::PkgsSync;
 use glob::Pattern;
 use rebuilderd_common::errors::*;
-use reqwest::blocking::Client;
+use reqwest::Client;
 use std::fs;
 
-pub fn fetch_url_or_path(client: &Client, path: &str) -> Result<Vec<u8>> {
+pub async fn fetch_url_or_path(client: &Client, path: &str) -> Result<Vec<u8>> {
     let bytes = if path.starts_with("https://") || path.starts_with("http://") {
         info!("Downloading {:?}...", path);
         client.get(path)
-            .send()?
-            .bytes()?
+            .send()
+            .await?
+            .bytes()
+            .await?
             .to_vec()
     } else {
         info!("Reading {:?}...", path);


### PR DESCRIPTION
async/await was more difficult to use with the libraries that have been around at that time, updating this to the current async/await.

@joyliu-q, this has solved the problem for me locally, if it works for you I'd go ahead and merge this, then close #56. Please let me know if there are any issues.

Thanks again for reporting!