### PR TITLE
Adds small QoL improvments to debian workers

### DIFF
--- a/daemon/src/api.rs
+++ b/daemon/src/api.rs
@@ -38,7 +38,7 @@ pub fn header<'a>(req: &'a HttpRequest, key: &str) -> Result<&'a str> {
 }
 
 fn modified_since_duration(req: &HttpRequest, datetime: DateTime<Utc>) -> Option<chrono::Duration> {
-    header(req, &http::header::IF_MODIFIED_SINCE.as_str()).ok()
+    header(req, http::header::IF_MODIFIED_SINCE.as_str()).ok()
         .and_then(|value| chrono::DateTime::parse_from_rfc2822(value).ok())
         .map(|value| value.signed_duration_since(datetime))
 }
@@ -177,7 +177,7 @@ fn get_worker_from_request(req: &HttpRequest, cfg: &Config, connection: &SqliteC
     } else {
         let worker = models::NewWorker::new(key.to_string(), ip, None);
         worker.insert(connection)?;
-        get_worker_from_request(req, &cfg, connection)
+        get_worker_from_request(req, cfg, connection)
     }
 }
 
@@ -370,7 +370,7 @@ pub async fn report_build(
     let mut pkg = models::Package::get_id(item.package_id, connection.as_ref())?;
 
     let build = models::NewBuild::from_api(&report);
-    let build = build.insert(&connection.as_ref())?;
+    let build = build.insert(connection.as_ref())?;
     pkg.build_id = Some(build);
 
     pkg.has_diffoscope = report.rebuild.diffoscope.is_some();

--- a/daemon/src/dashboard.rs
+++ b/daemon/src/dashboard.rs
@@ -79,7 +79,7 @@ impl DashboardState {
 
     pub fn get_response(&self) -> Result<&DashboardResponse> {
         if let Some(resp) =&self.response {
-            Ok(&resp)
+            Ok(resp)
         } else {
             bail!("No cached state")
         }

--- a/daemon/src/sync.rs
+++ b/daemon/src/sync.rs
@@ -81,7 +81,7 @@ fn sync(import: &mut SuiteImport, connection: &SqliteConnection) -> Result<()> {
             trace!("existing package: {:?}", existing);
             if existing.base_id.is_none() {
                 debug!("fixing base_id on: {:?}", existing);
-                let pkgbases = models::PkgBase::get_by(&base, &pkg.distro, &pkg.suite, Some(&pkg.architecture), connection)?
+                let pkgbases = models::PkgBase::get_by(base, &pkg.distro, &pkg.suite, Some(&pkg.architecture), connection)?
                     .into_iter()
                     .filter(|b| b.version == pkg.version)
                     .collect::<Vec<_>>();

--- a/tools/src/pager.rs
+++ b/tools/src/pager.rs
@@ -12,11 +12,11 @@ pub fn write(buf: &[u8]) -> Result<()> {
             .context("Failed to spawn pager")?;
 
         if let Some(mut stdin) = cmd.stdin.take() {
-            stdin.write_all(&buf).ok();
+            stdin.write_all(buf).ok();
         }
         cmd.wait()?;
     } else {
-        io::stdout().write_all(&buf).ok();
+        io::stdout().write_all(buf).ok();
     }
     Ok(())
 }

--- a/tools/src/schedule/archlinux.rs
+++ b/tools/src/schedule/archlinux.rs
@@ -135,17 +135,17 @@ pub async fn sync(sync: &PkgsSync) -> Result<Vec<PkgGroup>> {
 
     let mut bases: HashMap<_, PkgGroup> = HashMap::new();
     for arch in &sync.architectures {
-        let db = mirror_to_url(&source, &sync.suite, &arch, &format!("{}.db", sync.suite))?;
+        let db = mirror_to_url(source, &sync.suite, arch, &format!("{}.db", sync.suite))?;
         let bytes = fetch_url_or_path(&client, &db)
             .await?;
 
         info!("Parsing index ({} bytes)...", bytes.len());
         for pkg in extract_pkgs(&bytes)? {
-            if !pkg.matches(&sync) {
+            if !pkg.matches(sync) {
                 continue;
             }
 
-            let url = mirror_to_url(&source, &sync.suite, &arch, &pkg.filename)?;
+            let url = mirror_to_url(source, &sync.suite, arch, &pkg.filename)?;
             let artifact = PkgArtifact {
                 name: pkg.name,
                 url,

--- a/tools/src/schedule/debian.rs
+++ b/tools/src/schedule/debian.rs
@@ -151,7 +151,7 @@ pub async fn sync(sync: &PkgsSync) -> Result<Vec<PkgGroup>> {
 
         info!("Decompressing...");
         for pkg in extract_pkgs(&bytes)? {
-            if !pkg.matches(&sync) {
+            if !pkg.matches(sync) {
                 continue;
             }
 

--- a/worker/Dockerfile.debian
+++ b/worker/Dockerfile.debian
@@ -4,13 +4,12 @@ RUN apt-get update && apt-get install -y libssl-dev libsodium-dev
 COPY . .
 RUN cd worker; cargo build --release
 
-FROM debian:buster
-RUN echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list
-RUN apt-get update && apt-get install -y libssl-dev libsodium-dev devscripts/buster-backports sbuild
+FROM debian:bullseye
+RUN apt-get update && apt-get install -y libssl-dev libsodium-dev devscripts sbuild mmdebstrap
 COPY --from=0 \
     /usr/src/rebuilderd/worker/rebuilder-debian.sh \
     /usr/local/libexec/rebuilderd/
 COPY --from=0 \
     /usr/src/rebuilderd/target/release/rebuilderd-worker \
     /usr/local/bin/
-CMD ["rebuilderd-worker"]
+ENTRYPOINT ["rebuilderd-worker"]

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,0 +1,33 @@
+# Rebuilderd Workers
+
+Workers are tasked with, in short, carrying out the actual rebuild. Here you'll
+find:
+
+1. The rust codebase for the worker daemon (that listens in for rebuild
+   commands) under src/
+2. A series of entrypoints needed by the workers (i.e.,
+   rebuilder-{archlinux,debian}) to instantiate new build environments.
+3. A series of dockerfiles to build dockerized worker workloads (e.g., in case
+   you would want to use an [autoscaling group in a k8s
+   cluster](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
+   or in case you just want to keep workers separated).
+
+You can test workers individually by (for example) building a container and
+scheduling a build (for a debian worker):
+
+```bash
+$ docker build -t rebuilderd-worker-debian worker/Dockerfile.debian
+$ docker run --cap-add=SYS_ADMIN --rm \
+    rebuilderd-worker-debian build debian \
+    https://buildinfos.debian.net/buildinfo-pool/r/rust-sniffglue/rust-sniffglue_0.11.1-6+b1_amd64.buildinfo
+```
+
+| :memo: WARNING          |
+|:---------------------------|
+| note these commands are run in the root of the repo, not here|
+
+
+| :warning: WARNING          |
+|:---------------------------|
+| Running Debian workers as containers requires SYS\_ADMIN capabilities which could be dangerous!  |
+

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -73,7 +73,7 @@ async fn spawn_rebuilder_script_with_heartbeat<'a>(client: &Client, distro: &Dis
     let input = item.package.url.to_string();
 
     let ctx = Context {
-        distro: &distro,
+        distro,
         script_location: None,
         build: config.build.clone(),
         diffoscope: config.diffoscope.clone(),
@@ -104,7 +104,7 @@ async fn rebuild(client: &Client, config: &config::ConfigFile) -> Result<()> {
         JobAssignment::Rebuild(rb) => {
             info!("Starting rebuild of {:?} {:?}",  rb.package.name, rb.package.version);
             let distro = rb.package.distro.parse::<Distro>()?;
-            let rebuild = match spawn_rebuilder_script_with_heartbeat(&client, &distro, &rb, config).await {
+            let rebuild = match spawn_rebuilder_script_with_heartbeat(client, &distro, &rb, config).await {
                 Ok(res) => {
                     if res.status == BuildStatus::Good {
                         info!("Package successfully verified");


### PR DESCRIPTION
This PR contains the following:

1. Update from buster to bullseye
2. Explicitly install mmdebstrap
3. Use rebuilderd-worker as ENTRYPOINT
4. Adds a small readme on how to run these containers as single-shot