### PR TITLE
Change default cpu and io priority of rebuilderd-worker to idle

### DIFF
--- a/contrib/systemd/rebuilderd-worker@.service
+++ b/contrib/systemd/rebuilderd-worker@.service
@@ -2,10 +2,11 @@
 Description=rebuilderd-worker: rebuild packages
 
 [Service]
-ExecStart=/usr/bin/rebuilderd-worker -n %i connect
-
 Restart=always
 RestartSec=0
+ExecStart=/usr/bin/rebuilderd-worker -n %i connect
+CPUSchedulingPolicy=idle
+IOSchedulingClass=3
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This might help a bit if the builds and the daemon share a single server. Note there might still be performance issues if the server starts swapping due to low memory.