### PR TITLE
Arch Linux: Detect compression with tree_magic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
  "lazy_static",
  "log",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.11.1",
  "threadpool",
 ]
 
@@ -275,7 +275,7 @@ version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
- "memchr",
+ "memchr 2.3.4",
 ]
 
 [[package]]
@@ -444,10 +444,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -488,6 +512,15 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -710,9 +743,15 @@ checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.9",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
@@ -865,7 +904,7 @@ dependencies = [
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
+ "memchr 2.3.4",
  "pin-project-lite 0.2.7",
  "pin-utils",
  "proc-macro-hack",
@@ -1135,6 +1174,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
+name = "jobserver"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,6 +1262,15 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "lock_api"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
@@ -1240,6 +1297,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-sys"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb4b7c3eddad11d3af9e86c487607d2d2442d185d848575365c4856ba96d619"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,6 +1318,15 @@ name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
+name = "memchr"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memchr"
@@ -1411,6 +1488,15 @@ dependencies = [
 
 [[package]]
 name = "nom"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
+dependencies = [
+ "memchr 1.0.2",
+]
+
+[[package]]
+name = "nom"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
@@ -1418,7 +1504,7 @@ dependencies = [
  "bitvec",
  "funty",
  "lexical-core",
- "memchr",
+ "memchr 2.3.4",
  "version_check",
 ]
 
@@ -1507,13 +1593,37 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
+dependencies = [
+ "lock_api 0.3.4",
+ "parking_lot_core 0.7.2",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
- "lock_api",
- "parking_lot_core",
+ "lock_api 0.4.4",
+ "parking_lot_core 0.8.3",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
+dependencies = [
+ "cfg-if 0.1.10",
+ "cloudabi",
+ "libc",
+ "redox_syscall 0.1.57",
+ "smallvec",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1525,7 +1635,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.9",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -1543,6 +1653,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 dependencies = [
  "ucd-trie",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
 ]
 
 [[package]]
@@ -1682,7 +1802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
 dependencies = [
  "log",
- "parking_lot",
+ "parking_lot 0.11.1",
  "scheduled-thread-pool",
 ]
 
@@ -1778,13 +1898,15 @@ name = "rebuildctl"
 version = "0.13.0"
 dependencies = [
  "atty",
+ "base64",
+ "bzip2",
  "chrono",
  "colored",
  "dirs-next",
  "env_logger",
  "flate2",
  "glob",
- "nom",
+ "nom 6.2.1",
  "rebuilderd-common",
  "reqwest",
  "rust-lzma",
@@ -1794,6 +1916,9 @@ dependencies = [
  "tar",
  "tokio 1.9.0",
  "toml",
+ "tree_magic",
+ "xz",
+ "zstd",
 ]
 
 [[package]]
@@ -1867,6 +1992,12 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
+name = "redox_syscall"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
@@ -1881,7 +2012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom 0.2.3",
- "redox_syscall",
+ "redox_syscall 0.2.9",
 ]
 
 [[package]]
@@ -1891,7 +2022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
 dependencies = [
  "aho-corasick",
- "memchr",
+ "memchr 2.3.4",
  "regex-syntax",
 ]
 
@@ -2013,7 +2144,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
 dependencies = [
- "parking_lot",
+ "parking_lot 0.11.1",
 ]
 
 [[package]]
@@ -2349,7 +2480,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand 0.8.4",
- "redox_syscall",
+ "redox_syscall 0.2.9",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -2475,7 +2606,7 @@ dependencies = [
  "iovec",
  "lazy_static",
  "libc",
- "memchr",
+ "memchr 2.3.4",
  "mio 0.6.23",
  "mio-uds",
  "pin-project-lite 0.1.12",
@@ -2493,7 +2624,7 @@ dependencies = [
  "autocfg",
  "bytes 1.0.1",
  "libc",
- "memchr",
+ "memchr 2.3.4",
  "mio 0.7.13",
  "num_cpus",
  "once_cell",
@@ -2596,6 +2727,19 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project 1.0.8",
  "tracing",
+]
+
+[[package]]
+name = "tree_magic"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d99367ce3e553a84738f73bd626ccca541ef90ae757fdcdc4cbe728e6cb629"
+dependencies = [
+ "fnv",
+ "lazy_static",
+ "nom 3.2.1",
+ "parking_lot 0.10.2",
+ "petgraph",
 ]
 
 [[package]]
@@ -2921,5 +3065,52 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "xz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c887690ff2a2e233e8e49633461521f98ec57fbff9d59a884c9a4f04ec1da34"
+dependencies = [
+ "xz2",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c179869f34fc7c01830d3ce7ea2086bc3a07e0d35289b667d0a8bf910258926c"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
+name = "zstd"
+version = "0.9.0+zstd.1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07749a5dc2cb6b36661290245e350f15ec3bbb304e493db54a1d354480522ccd"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "4.1.1+zstd.1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91c90f2c593b003603e5e0493c837088df4469da25aafff8bce42ba48caf079"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.6.1+zstd.1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "615120c7a2431d16cf1cf979e7fc31ba7a5b5e5707b29c8a99e5dbf8a8392a33"
+dependencies = [
+ "cc",
  "libc",
 ]

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -33,3 +33,10 @@ glob = "0.3.0"
 nom = "6"
 tokio = { version="1", features=["macros", "rt-multi-thread", "io-std", "io-util"] }
 atty = "0.2.14"
+tree_magic = "0.2.3"
+bzip2 = "0.4.3"
+xz = "0.1.0"
+zstd = "0.9.0"
+
+[dev-dependencies]
+base64 = "0.13.0"

--- a/tools/src/decompress.rs
+++ b/tools/src/decompress.rs
@@ -1,0 +1,133 @@
+use rebuilderd_common::errors::*;
+use std::io::Read;
+use flate2::read::GzDecoder;
+use bzip2::read::BzDecoder;
+use xz::read::XzDecoder;
+
+#[derive(Debug, PartialEq)]
+pub enum CompressedWith {
+    // .gz
+    Gzip,
+    // .bz2
+    Bzip2,
+    // .xz
+    Xz,
+    // .zstd
+    Zstd,
+    Unknown,
+}
+
+pub fn detect_compression(bytes: &[u8]) -> CompressedWith {
+    let mime = tree_magic::from_u8(bytes);
+    debug!("Detected mimetype for possibly compressed data: {:?}", mime);
+
+    match mime.as_str() {
+        "application/gzip" => CompressedWith::Gzip,
+        "application/x-bzip" => CompressedWith::Bzip2,
+        "application/x-xz" => CompressedWith::Xz,
+        "application/zstd" => CompressedWith::Zstd,
+        _ => CompressedWith::Unknown,
+    }
+}
+
+pub fn stream<'a>(comp: CompressedWith, bytes: &'a [u8]) -> Result<Box<dyn Read + 'a>> {
+    match comp {
+        CompressedWith::Gzip => Ok(Box::new(GzDecoder::new(bytes))),
+        CompressedWith::Bzip2 => Ok(Box::new(BzDecoder::new(bytes))),
+        CompressedWith::Xz => Ok(Box::new(XzDecoder::new(bytes))),
+        CompressedWith::Zstd => Ok(Box::new(zstd::Decoder::new(bytes)?)),
+        CompressedWith::Unknown => Ok(Box::new(bytes)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_no_compression() {
+        let comp = detect_compression(b"ohai");
+        assert_eq!(comp, CompressedWith::Unknown);
+    }
+
+    #[test]
+    fn decompress_no_compression() {
+        let bytes = b"ohai";
+        let comp = detect_compression(bytes);
+        let mut buf = Vec::new();
+        stream(comp, bytes).unwrap().read_to_end(&mut buf).unwrap();
+        assert_eq!(bytes, b"ohai");
+    }
+
+    #[test]
+    fn detect_gzip_compression() {
+        let bytes = base64::decode("H4sIAAAAAAAAA8vPSMzkAgCKUC0+BQAAAA==").unwrap();
+        let comp = detect_compression(&bytes);
+        assert_eq!(comp, CompressedWith::Gzip);
+    }
+
+    #[test]
+    fn decompress_gzip_compression() {
+        let bytes = base64::decode("H4sIAAAAAAAAA8vPSMzkAgCKUC0+BQAAAA==").unwrap();
+        let comp = detect_compression(&bytes);
+        assert_eq!(comp, CompressedWith::Gzip);
+
+        let mut buf = Vec::new();
+        stream(comp, &bytes).unwrap().read_to_end(&mut buf).unwrap();
+        assert_eq!(buf, b"ohai\n");
+    }
+
+    #[test]
+    fn detect_bzip2_compression() {
+        let bytes = base64::decode("QlpoOTFBWSZTWZ+CN7sAAAJBAAAQIGCgADDNAMGmwHF3JFOFCQn4I3uw").unwrap();
+        let comp = detect_compression(&bytes);
+        assert_eq!(comp, CompressedWith::Bzip2);
+    }
+
+    #[test]
+    fn decompress_bzip2_compression() {
+        let bytes = base64::decode("QlpoOTFBWSZTWZ+CN7sAAAJBAAAQIGCgADDNAMGmwHF3JFOFCQn4I3uw").unwrap();
+        let comp = detect_compression(&bytes);
+        assert_eq!(comp, CompressedWith::Bzip2);
+
+        let mut buf = Vec::new();
+        stream(comp, &bytes).unwrap().read_to_end(&mut buf).unwrap();
+        assert_eq!(buf, b"ohai\n");
+    }
+
+    #[test]
+    fn detect_xz_compression() {
+        let bytes = base64::decode("/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQAEb2hhaQoAAAAACyuekVbXbHMAAR0FuC2Arx+2830BAAAAAARZWg==").unwrap();
+        let comp = detect_compression(&bytes);
+        assert_eq!(comp, CompressedWith::Xz);
+    }
+
+    #[test]
+    fn decompress_xz_compression() {
+        let bytes = base64::decode("/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQAEb2hhaQoAAAAACyuekVbXbHMAAR0FuC2Arx+2830BAAAAAARZWg==").unwrap();
+        let comp = detect_compression(&bytes);
+        assert_eq!(comp, CompressedWith::Xz);
+
+        let mut buf = Vec::new();
+        stream(comp, &bytes).unwrap().read_to_end(&mut buf).unwrap();
+        assert_eq!(buf, b"ohai\n");
+    }
+
+    #[test]
+    fn detect_zstd_compression() {
+        let bytes = base64::decode("KLUv/QRYKQAAb2hhaQpnBE++").unwrap();
+        let comp = detect_compression(&bytes);
+        assert_eq!(comp, CompressedWith::Zstd);
+    }
+
+    #[test]
+    fn decompress_zstd_compression() {
+        let bytes = base64::decode("KLUv/QRYKQAAb2hhaQpnBE++").unwrap();
+        let comp = detect_compression(&bytes);
+        assert_eq!(comp, CompressedWith::Zstd);
+
+        let mut buf = Vec::new();
+        stream(comp, &bytes).unwrap().read_to_end(&mut buf).unwrap();
+        assert_eq!(buf, b"ohai\n");
+    }
+}

--- a/tools/src/main.rs
+++ b/tools/src/main.rs
@@ -16,6 +16,7 @@ use tokio::io::AsyncReadExt;
 
 pub mod args;
 pub mod config;
+pub mod decompress;
 pub mod pager;
 pub mod schedule;
 

--- a/tools/src/schedule/archlinux.rs
+++ b/tools/src/schedule/archlinux.rs
@@ -1,6 +1,6 @@
 use crate::args::PkgsSync;
+use crate::decompress;
 use crate::schedule::{Pkg, fetch_url_or_path};
-use flate2::read::GzDecoder;
 use nom::bytes::complete::take_till;
 use rebuilderd_common::{PkgGroup, PkgArtifact, Distro};
 use rebuilderd_common::errors::*;
@@ -82,7 +82,8 @@ impl TryInto<ArchPkg> for NewPkg {
 }
 
 pub fn extract_pkgs(bytes: &[u8]) -> Result<Vec<ArchPkg>> {
-    let tar = GzDecoder::new(bytes);
+    let comp = decompress::detect_compression(bytes);
+    let tar = decompress::stream(comp, bytes)?;
     let mut archive = Archive::new(tar);
 
     let mut pkgs = Vec::new();


### PR DESCRIPTION
This does mime-type detection with [tree_magic](https://github.com/aahancoc/tree_magic/) and then picks the right decompressor from:

- gzip
- bzip2
- xz
- zstd

Everything else is passed through as-is since "no compression" seems to be supported too in repo-add.

Resolves #61 (@adityasaky)