### PR TITLE
Track required and supported rebuild backends

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ worker/build
 worker/cache
 daemon/rebuilderd.db*
 contrib
+/data

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -6,14 +6,52 @@ on:
 
 jobs:
   push_to_registry:
-    name: Push Docker image to GitHub Packages
+    name: Push Docker image to GitHub Registry
     runs-on: ubuntu-latest
     steps:
-    - name: Check out the repo
-      uses: actions/checkout@v2
-    - name: Push to GitHub Packages
-      uses: docker/build-push-action@v2
-      with:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-        tag_with_ref: true
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ghcr.io/kpcyrd/rebuilderd
+          tags: |
+            type=semver,pattern={{raw}}
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      -
+        name: Login to Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push Docker images
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      -
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,21 +1,52 @@
 name: Docker
 
 on:
+  # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Build the Docker image
-      run: docker build -t rebuilderd .
-    - name: Test the Docker image (rebuilderd)
-      run: docker run --rm rebuilderd rebuilderd --help
-    - name: Test the Docker image (rebuildctl)
-      run: docker run --rm rebuilderd rebuildctl --help
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      -
+        name: Build Docker images
+        uses: docker/build-push-action@v2
+        with:
+          load: true
+          tags: rebuilderd
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      -
+        name: Test Docker image (rebuilderd)
+        run: docker run --rm rebuilderd rebuilderd --help
+      -
+        name: Test Docker image (rebuildctl)
+        run: docker run --rm rebuilderd rebuildctl --help
+      -
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ contrib/*.1
 /worker/rebuilder.key
 /worker/build/
 /worker/cache/
+/data/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452299e87817ae5673910e53c243484ca38be3828db819b6011736fc6982e874"
+checksum = "5cb8958da437716f3f31b0e76f8daf36554128517d7df37ceba7df00f09622ee"
 dependencies = [
  "actix-codec",
  "actix-connect",
@@ -177,7 +177,7 @@ dependencies = [
  "lazy_static",
  "log",
  "num_cpus",
- "parking_lot 0.11.1",
+ "parking_lot",
  "threadpool",
 ]
 
@@ -275,7 +275,7 @@ version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
- "memchr 2.3.4",
+ "memchr",
 ]
 
 [[package]]
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
 name = "arrayvec"
@@ -301,9 +301,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-trait"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
+checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -512,15 +512,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -737,13 +728,13 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
+checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.9",
+ "redox_syscall",
  "winapi 0.3.9",
 ]
 
@@ -904,7 +895,7 @@ dependencies = [
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr 2.3.4",
+ "memchr",
  "pin-project-lite 0.2.7",
  "pin-utils",
  "proc-macro-hack",
@@ -993,7 +984,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tokio-util 0.6.7",
  "tracing",
 ]
@@ -1046,9 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
+checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
 dependencies = [
  "bytes 1.0.1",
  "http",
@@ -1090,8 +1081,8 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite 0.2.7",
- "socket2 0.4.0",
- "tokio 1.9.0",
+ "socket2 0.4.1",
+ "tokio 1.10.0",
  "tower-service",
  "tracing",
  "want",
@@ -1106,7 +1097,7 @@ dependencies = [
  "bytes 1.0.1",
  "hyper",
  "native-tls",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tokio-native-tls",
 ]
 
@@ -1175,18 +1166,18 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "jobserver"
-version = "0.1.22"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1228,9 +1219,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "libsodium-sys"
@@ -1259,15 +1250,6 @@ name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
-
-[[package]]
-name = "lock_api"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "lock_api"
@@ -1315,18 +1297,9 @@ checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-
-[[package]]
-name = "memchr"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
-dependencies = [
- "libc",
-]
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -1446,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1475,24 +1448,15 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1e25ee6b412c2a1e3fcb6a4499a5c1bfe7f43e014bdce9a6b6666e5aa2d187"
+checksum = "e7555d6c7164cc913be1ce7f95cbecdabda61eb2ccd89008524af306fb7f5031"
 dependencies = [
  "bitflags",
  "cc",
  "cfg-if 1.0.0",
  "libc",
  "memoffset",
-]
-
-[[package]]
-name = "nom"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
-dependencies = [
- "memchr 1.0.2",
 ]
 
 [[package]]
@@ -1504,7 +1468,7 @@ dependencies = [
  "bitvec",
  "funty",
  "lexical-core",
- "memchr 2.3.4",
+ "memchr",
  "version_check",
 ]
 
@@ -1560,9 +1524,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.35"
+version = "0.10.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
+checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1580,9 +1544,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.65"
+version = "0.9.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
+checksum = "1996d2d305e561b70d1ee0c53f1542833f4e1ac6ce9a6708b6ff2738ca67dc82"
 dependencies = [
  "autocfg",
  "cc",
@@ -1593,37 +1557,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.7.2",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
- "lock_api 0.4.4",
- "parking_lot_core 0.8.3",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
-dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
- "libc",
- "redox_syscall 0.1.57",
- "smallvec",
- "winapi 0.3.9",
+ "lock_api",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1635,7 +1575,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.2.9",
+ "redox_syscall",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -1802,7 +1742,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
 dependencies = [
  "log",
- "parking_lot 0.11.1",
+ "parking_lot",
  "scheduled-thread-pool",
 ]
 
@@ -1906,7 +1846,7 @@ dependencies = [
  "env_logger",
  "flate2",
  "glob",
- "nom 6.2.1",
+ "nom",
  "rebuilderd-common",
  "reqwest",
  "rust-lzma",
@@ -1914,9 +1854,9 @@ dependencies = [
  "serde_json",
  "structopt",
  "tar",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "toml",
- "tree_magic",
+ "tree_magic_mini",
  "xz",
  "zstd",
 ]
@@ -1967,7 +1907,7 @@ dependencies = [
  "rebuilderd-common",
  "structopt",
  "tempfile",
- "tokio 1.9.0",
+ "tokio 1.10.0",
 ]
 
 [[package]]
@@ -1985,22 +1925,16 @@ dependencies = [
  "sodiumoxide",
  "structopt",
  "tempfile",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "toml",
  "url",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -2012,7 +1946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom 0.2.3",
- "redox_syscall 0.2.9",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -2022,7 +1956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
 dependencies = [
  "aho-corasick",
- "memchr 2.3.4",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -2067,7 +2001,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tokio-native-tls",
  "url",
  "wasm-bindgen",
@@ -2144,7 +2078,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
 dependencies = [
- "parking_lot 0.11.1",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2211,18 +2145,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2231,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",
@@ -2288,9 +2222,9 @@ checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 
 [[package]]
 name = "slab"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
 name = "smallvec"
@@ -2311,9 +2245,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -2427,15 +2361,15 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
+checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
 
 [[package]]
 name = "strum_macros"
-version = "0.20.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
+checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2462,9 +2396,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.35"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d779dc6aeff029314570f666ec83f19df7280bb36ef338442cfa8c604021b80"
+checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
 dependencies = [
  "filetime",
  "libc",
@@ -2480,7 +2414,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand 0.8.4",
- "redox_syscall 0.2.9",
+ "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -2606,7 +2540,7 @@ dependencies = [
  "iovec",
  "lazy_static",
  "libc",
- "memchr 2.3.4",
+ "memchr",
  "mio 0.6.23",
  "mio-uds",
  "pin-project-lite 0.1.12",
@@ -2617,14 +2551,14 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
+checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
 dependencies = [
  "autocfg",
  "bytes 1.0.1",
  "libc",
- "memchr 2.3.4",
+ "memchr",
  "mio 0.7.13",
  "num_cpus",
  "once_cell",
@@ -2652,7 +2586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.9.0",
+ "tokio 1.10.0",
 ]
 
 [[package]]
@@ -2680,7 +2614,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.2.7",
- "tokio 1.9.0",
+ "tokio 1.10.0",
 ]
 
 [[package]]
@@ -2712,9 +2646,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
 dependencies = [
  "lazy_static",
 ]
@@ -2730,15 +2664,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree_magic"
-version = "0.2.3"
+name = "tree_magic_mini"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d99367ce3e553a84738f73bd626ccca541ef90ae757fdcdc4cbe728e6cb629"
+checksum = "0687683589ce7d3912e6bf52c1620d970fbed86c27e12118ca779a3780bbf888"
 dependencies = [
  "fnv",
  "lazy_static",
- "nom 3.2.1",
- "parking_lot 0.10.2",
+ "nom",
+ "once_cell",
  "petgraph",
 ]
 
@@ -2801,12 +2735,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
-dependencies = [
- "matches",
-]
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
 
 [[package]]
 name = "unicode-normalization"
@@ -2900,9 +2831,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -2912,9 +2843,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2927,9 +2858,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
+checksum = "16646b21c3add8e13fdb8f20172f8a28c3dbf62f45406bcff0233188226cfe0c"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2939,9 +2870,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2949,9 +2880,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2962,15 +2893,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
 
 [[package]]
 name = "web-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,20 @@
+# synax = docker/dockerfile:1.2
 FROM rust:alpine3.14
 ENV RUSTFLAGS="-C target-feature=-crt-static"
 WORKDIR /usr/src/rebuilderd
 RUN apk add --no-cache musl-dev openssl-dev sqlite-dev xz-dev
 COPY . .
-RUN cd daemon; cargo build --release
-RUN cd tools; cargo build --release
+RUN --mount=type=cache,target=/var/cache/buildkit \
+    CARGO_HOME=/var/cache/buildkit/cargo \
+    CARGO_TARGET_DIR=/var/cache/buildkit/target \
+    cargo build --release --locked -p rebuilderd -p rebuildctl && \
+    cp -v /var/cache/buildkit/target/release/rebuilderd \
+        /var/cache/buildkit/target/release/rebuildctl /
 
 FROM alpine:3.14
 ENV HTTP_ADDR=0.0.0.0:8484
 RUN apk add --no-cache libgcc openssl dpkg sqlite-libs xz
 COPY --from=0 \
-    /usr/src/rebuilderd/target/release/rebuilderd \
-    /usr/src/rebuilderd/target/release/rebuildctl \
+    /rebuilderd /rebuildctl \
     /usr/local/bin/
 CMD ["rebuilderd"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:alpine3.12
+FROM rust:alpine3.14
 ENV RUSTFLAGS="-C target-feature=-crt-static"
 WORKDIR /usr/src/rebuilderd
 RUN apk add --no-cache musl-dev openssl-dev sqlite-dev xz-dev
@@ -6,7 +6,7 @@ COPY . .
 RUN cd daemon; cargo build --release
 RUN cd tools; cargo build --release
 
-FROM alpine:3.12
+FROM alpine:3.14
 ENV HTTP_ADDR=0.0.0.0:8484
 RUN apk add --no-cache libgcc openssl dpkg sqlite-libs xz
 COPY --from=0 \

--- a/README.md
+++ b/README.md
@@ -101,6 +101,50 @@ confirm successful rebuilds is very helpful.
 
 Please see the setup instructions in the [Arch Linux Wiki](https://wiki.archlinux.org/index.php/Rebuilderd).
 
+# Development with docker
+
+There is a docker-compose setup in the repo, to start a basic stack simply
+clone the repository and run:
+
+```sh
+DOCKER_BUILDKIT=1 docker-compose up
+```
+
+The initial build is going to take some time.
+
+To recompile your changes (you can optionally specify a specific image to build):
+
+```sh
+DOCKER_BUILDKIT=1 docker-compose build
+```
+
+To connect to your local instance, use this command to compile and run the `rebuildctl` binary.
+
+```sh
+REBUILDERD_COOKIE_PATH=data/auth cargo run -p rebuildctl -- -v status
+```
+
+Sync a package index that should be rebuilt (takes a bit):
+
+```sh
+REBUILDERD_COOKIE_PATH=data/auth cargo run -p rebuildctl -- pkgs sync archlinux community \
+     'https://ftp.halifax.rwth-aachen.de/archlinux/$repo/os/$arch' \
+    --architecture x86_64 --maintainer kpcyrd
+```
+
+Display the build queue to test it's working:
+
+```sh
+REBUILDERD_COOKIE_PATH=data/auth cargo run -p rebuildctl -- queue ls --head
+```
+
+Monitor the logs of your workers with those two commands:
+
+```sh
+REBUILDERD_COOKIE_PATH=data/auth cargo run -p rebuildctl -- status
+REBUILDERD_COOKIE_PATH=data/auth cargo run -p rebuildctl -- pkgs ls
+```
+
 # Development
 
 A rebuilder consists of the `rebuilderd` daemon and >= 1 workers:

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -13,8 +13,8 @@ edition = "2018"
 anyhow = "1.0.32"
 log = "0.4"
 serde = { version="1.0", features=["derive"] }
-strum = "0.20"
-strum_macros = "0.20"
+strum = "0.21"
+strum_macros = "0.21"
 reqwest = { version="0.11", features=["blocking", "json"] }
 chrono = { version = "0.4", features=["serde"] }
 colored = "2"

--- a/common/src/api.rs
+++ b/common/src/api.rs
@@ -251,6 +251,7 @@ pub struct Worker {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct WorkQuery {
+    pub supported_backends: Vec<String>,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/common/src/auth.rs
+++ b/common/src/auth.rs
@@ -1,5 +1,6 @@
 use crate::errors::*;
 use serde::Deserialize;
+use std::env;
 use std::fs;
 use std::path::Path;
 
@@ -41,6 +42,10 @@ fn read_cookie_from_file<P: AsRef<Path>>(path: P) -> Result<String> {
 }
 
 pub fn find_auth_cookie() -> Result<String> {
+    if let Ok(cookie_path) = env::var("REBUILDERD_COOKIE_PATH") {
+        return read_cookie_from_file(cookie_path);
+    }
+
     if let Some(config_dir) = dirs_next::config_dir() {
         let path = config_dir.join("rebuilderd.conf");
         if let Some(cookie) = read_cookie_from_config(path)? {

--- a/daemon/migrations/2021-08-04-171946_queue-per-distro/down.sql
+++ b/daemon/migrations/2021-08-04-171946_queue-per-distro/down.sql
@@ -1,0 +1,24 @@
+PRAGMA foreign_keys=off;
+
+CREATE TABLE _queue_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    package_id INTEGER NOT NULL,
+    version VARCHAR NOT NULL,
+    priority INTEGER NOT NULL,
+    queued_at DATETIME NOT NULL,
+    worker_id INTEGER,
+    started_at DATETIME,
+    last_ping DATETIME,
+    FOREIGN KEY(package_id) REFERENCES packages(id) ON DELETE CASCADE,
+    FOREIGN KEY(worker_id) REFERENCES workers(id) ON DELETE SET NULL,
+    CONSTRAINT queue_unique UNIQUE (package_id, version)
+);
+
+INSERT INTO _queue_new (id, package_id, version, priority, queued_at, worker_id, started_at, last_ping)
+    SELECT id, package_id, version, priority, queued_at, worker_id, started_at, last_ping
+    FROM queue;
+
+DROP TABLE queue;
+ALTER TABLE _queue_new RENAME TO queue;
+
+PRAGMA foreign_keys=on;

--- a/daemon/migrations/2021-08-04-171946_queue-per-distro/up.sql
+++ b/daemon/migrations/2021-08-04-171946_queue-per-distro/up.sql
@@ -1,0 +1,27 @@
+PRAGMA foreign_keys=off;
+
+CREATE TABLE _queue_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    package_id INTEGER NOT NULL,
+    version VARCHAR NOT NULL,
+    required_backend VARCHAR NOT NULL,
+    priority INTEGER NOT NULL,
+    queued_at DATETIME NOT NULL,
+    worker_id INTEGER,
+    started_at DATETIME,
+    last_ping DATETIME,
+    FOREIGN KEY(package_id) REFERENCES packages(id) ON DELETE CASCADE,
+    FOREIGN KEY(worker_id) REFERENCES workers(id) ON DELETE SET NULL,
+    CONSTRAINT queue_unique UNIQUE (package_id, version)
+);
+
+INSERT INTO _queue_new (id, package_id, version, required_backend, priority, queued_at, worker_id, started_at, last_ping)
+    SELECT id, package_id, version, "", priority, queued_at, worker_id, started_at, last_ping
+    FROM queue;
+
+DROP TABLE queue;
+ALTER TABLE _queue_new RENAME TO queue;
+
+CREATE UNIQUE INDEX queue_pop_idx ON queue(required_backend, priority, queued_at, id);
+
+PRAGMA foreign_keys=on;

--- a/daemon/src/schema.rs
+++ b/daemon/src/schema.rs
@@ -45,6 +45,7 @@ table! {
         id -> Integer,
         package_id -> Integer,
         version -> Text,
+        required_backend -> Text,
         priority -> Integer,
         queued_at -> Timestamp,
         worker_id -> Nullable<Integer>,

--- a/daemon/src/sync.rs
+++ b/daemon/src/sync.rs
@@ -196,7 +196,7 @@ fn sync(import: &mut SuiteImport, connection: &SqliteConnection) -> Result<()> {
     // TODO: check if queueing has been disabled in the request, eg. to initially fill the database
     for pkgs in queue.chunks(1_000) {
         debug!("queue: {:?}", pkgs.len());
-        models::Queued::queue_batch(pkgs, 1, connection)?;
+        models::Queued::queue_batch(pkgs, import.distro.to_string(), 1, connection)?;
     }
     info!("successfully updated state");
 
@@ -210,7 +210,7 @@ fn retry(import: &SuiteImport, connection: &SqliteConnection) -> Result<()> {
     info!("queueing new jobs");
     for pkgs in queue.chunks(1_000) {
         debug!("queue: {:?}", pkgs.len());
-        models::Queued::queue_batch(pkgs, 2, connection)?;
+        models::Queued::queue_batch(pkgs, import.distro.to_string(), 2, connection)?;
     }
     info!("successfully triggered {} retries", queue.len());
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,23 +5,49 @@ services:
     build: .
     ports:
     - 127.0.0.1:8484:8484
+    init: true
+    command: ['rebuilderd', '-v']
+    environment:
+    - REBUILDERD_COOKIE_PATH=/secret/auth
+    - RUST_LOG=debug
+    volumes:
+       - ./data:/secret
   worker-alpine:
     build:
       context: .
       dockerfile: worker/Dockerfile.alpine
+    # number of concurrent workers
+    scale: 1
+    init: true
+    command: ['connect', 'http://daemon:8484']
     environment:
-    - REBUILDER_ADDR=http://daemon:8484
+    - REBUILDERD_COOKIE_PATH=/secret/auth
+    volumes:
+       - ./data:/secret
   worker-archlinux:
     build:
       context: .
       dockerfile: worker/Dockerfile.archlinux
+    # number of concurrent workers
+    scale: 1
+    init: true
+    command: ['connect', 'http://daemon:8484']
     environment:
-    - REBUILDER_ADDR=http://daemon:8484
+    - REBUILDERD_COOKIE_PATH=/secret/auth
+    volumes:
+       - ./data:/secret
   worker-debian:
     build:
       context: .
       dockerfile: worker/Dockerfile.debian
+    # TODO: drop this after the next mmdebstrap release (currently 0.7.5)
     cap_add:
     - SYS_ADMIN
+    # number of concurrent workers
+    scale: 1
+    init: true
+    command: ['connect', 'http://daemon:8484']
     environment:
-    - REBUILDER_ADDR=http://daemon:8484
+    - REBUILDERD_COOKIE_PATH=/secret/auth
+    volumes:
+       - ./data:/secret

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -137,7 +137,9 @@ async fn main() -> Result<()> {
     }).await?;
 
     test("Testing there is nothing to do", async {
-        let task = client.pop_queue(&WorkQuery {}).await?;
+        let task = client.pop_queue(&WorkQuery {
+            supported_backends: vec!["archlinux".to_string()],
+        }).await?;
 
         if task != JobAssignment::Nothing {
             bail!("Got a job assigned");
@@ -192,7 +194,9 @@ async fn main() -> Result<()> {
     }).await?;
 
     test("Fetching task and reporting BAD rebuild", async {
-        let task = client.pop_queue(&WorkQuery {}).await?;
+        let task = client.pop_queue(&WorkQuery {
+            supported_backends: vec!["archlinux".to_string()],
+        }).await?;
 
         let queue = match task {
             JobAssignment::Rebuild(item) => *item,
@@ -269,7 +273,9 @@ async fn main() -> Result<()> {
     }).await?;
 
     test("Fetching task and reporting GOOD rebuild", async {
-        let task = client.pop_queue(&WorkQuery {}).await?;
+        let task = client.pop_queue(&WorkQuery {
+            supported_backends: vec!["archlinux".to_string()],
+        }).await?;
 
         let queue = match task {
             JobAssignment::Rebuild(item) => *item,

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -33,7 +33,7 @@ glob = "0.3.0"
 nom = "6"
 tokio = { version="1", features=["macros", "rt-multi-thread", "io-std", "io-util"] }
 atty = "0.2.14"
-tree_magic = "0.2.3"
+tree_magic_mini = "3"
 bzip2 = "0.4.3"
 xz = "0.1.0"
 zstd = "0.9.0"

--- a/tools/src/decompress.rs
+++ b/tools/src/decompress.rs
@@ -18,10 +18,10 @@ pub enum CompressedWith {
 }
 
 pub fn detect_compression(bytes: &[u8]) -> CompressedWith {
-    let mime = tree_magic::from_u8(bytes);
+    let mime = tree_magic_mini::from_u8(bytes);
     debug!("Detected mimetype for possibly compressed data: {:?}", mime);
 
-    match mime.as_str() {
+    match mime {
         "application/gzip" => CompressedWith::Gzip,
         "application/x-bzip" => CompressedWith::Bzip2,
         "application/x-xz" => CompressedWith::Xz,

--- a/worker/Dockerfile.alpine
+++ b/worker/Dockerfile.alpine
@@ -1,13 +1,13 @@
-FROM rust:alpine3.10
+FROM rust:alpine3.14
 ENV RUSTFLAGS="-C target-feature=-crt-static"
 WORKDIR /usr/src/rebuilderd
 RUN apk add --no-cache musl-dev openssl-dev pkgconfig libsodium-dev
 COPY . .
 RUN cd worker; cargo build --release
 
-FROM alpine:3.10
+FROM alpine:3.14
 RUN apk add --no-cache libgcc openssl libsodium
 COPY --from=0 \
     /usr/src/rebuilderd/target/release/rebuilderd-worker \
     /usr/local/bin/
-CMD ["rebuilderd-worker"]
+ENTRYPOINT ["rebuilderd-worker"]

--- a/worker/Dockerfile.alpine
+++ b/worker/Dockerfile.alpine
@@ -1,13 +1,16 @@
+# synax = docker/dockerfile:1.2
 FROM rust:alpine3.14
 ENV RUSTFLAGS="-C target-feature=-crt-static"
 WORKDIR /usr/src/rebuilderd
 RUN apk add --no-cache musl-dev openssl-dev pkgconfig libsodium-dev
 COPY . .
-RUN cd worker; cargo build --release
+RUN --mount=type=cache,target=/var/cache/buildkit \
+    CARGO_HOME=/var/cache/buildkit/cargo \
+    CARGO_TARGET_DIR=/var/cache/buildkit/alpine/target \
+    cargo build --release --locked -p rebuilderd-worker && \
+    cp -v /var/cache/buildkit/alpine/target/release/rebuilderd-worker /
 
 FROM alpine:3.14
 RUN apk add --no-cache libgcc openssl libsodium
-COPY --from=0 \
-    /usr/src/rebuilderd/target/release/rebuilderd-worker \
-    /usr/local/bin/
+COPY --from=0 /rebuilderd-worker /usr/local/bin/
 ENTRYPOINT ["rebuilderd-worker"]

--- a/worker/Dockerfile.archlinux
+++ b/worker/Dockerfile.archlinux
@@ -1,6 +1,6 @@
 FROM archlinux
 WORKDIR /usr/src/rebuilderd
-RUN pacman -Suy --noconfirm gcc cargo openssl libsodium
+RUN pacman -Suy --noconfirm gcc pkgconf cargo openssl libsodium
 COPY . .
 RUN cd worker; cargo build --release
 
@@ -12,4 +12,4 @@ COPY --from=0 \
 COPY --from=0 \
     /usr/src/rebuilderd/target/release/rebuilderd-worker \
     /usr/local/bin/
-CMD ["rebuilderd-worker"]
+ENTRYPOINT ["rebuilderd-worker"]

--- a/worker/Dockerfile.archlinux
+++ b/worker/Dockerfile.archlinux
@@ -1,15 +1,18 @@
+# synax = docker/dockerfile:1.2
 FROM archlinux
 WORKDIR /usr/src/rebuilderd
 RUN pacman -Suy --noconfirm gcc pkgconf cargo openssl libsodium
 COPY . .
-RUN cd worker; cargo build --release
+RUN --mount=type=cache,target=/var/cache/buildkit \
+    CARGO_HOME=/var/cache/buildkit/cargo \
+    CARGO_TARGET_DIR=/var/cache/buildkit/archlinux/target \
+    cargo build --release --locked -p rebuilderd-worker && \
+    cp -v /var/cache/buildkit/archlinux/target/release/rebuilderd-worker /
 
 FROM archlinux
 RUN pacman -Suy --noconfirm archlinux-repro openssl libsodium
 COPY --from=0 \
     /usr/src/rebuilderd/worker/rebuilder-archlinux.sh \
     /usr/local/libexec/rebuilderd/
-COPY --from=0 \
-    /usr/src/rebuilderd/target/release/rebuilderd-worker \
-    /usr/local/bin/
+COPY --from=0 /rebuilderd-worker /usr/local/bin/
 ENTRYPOINT ["rebuilderd-worker"]

--- a/worker/Dockerfile.debian
+++ b/worker/Dockerfile.debian
@@ -1,4 +1,4 @@
-FROM rust:buster
+FROM rust:bullseye
 WORKDIR /usr/src/rebuilderd
 RUN apt-get update && apt-get install -y libssl-dev libsodium-dev
 COPY . .

--- a/worker/Dockerfile.debian
+++ b/worker/Dockerfile.debian
@@ -1,15 +1,18 @@
+# synax = docker/dockerfile:1.2
 FROM rust:bullseye
 WORKDIR /usr/src/rebuilderd
 RUN apt-get update && apt-get install -y libssl-dev libsodium-dev
 COPY . .
-RUN cd worker; cargo build --release
+RUN --mount=type=cache,target=/var/cache/buildkit \
+    CARGO_HOME=/var/cache/buildkit/cargo \
+    CARGO_TARGET_DIR=/var/cache/buildkit/debian/target \
+    cargo build --release --locked -p rebuilderd-worker && \
+    cp -v /var/cache/buildkit/debian/target/release/rebuilderd-worker /
 
 FROM debian:bullseye
 RUN apt-get update && apt-get install -y libssl-dev libsodium-dev devscripts sbuild mmdebstrap
 COPY --from=0 \
     /usr/src/rebuilderd/worker/rebuilder-debian.sh \
     /usr/local/libexec/rebuilderd/
-COPY --from=0 \
-    /usr/src/rebuilderd/target/release/rebuilderd-worker \
-    /usr/local/bin/
+COPY --from=0 /rebuilderd-worker /usr/local/bin/
 ENTRYPOINT ["rebuilderd-worker"]

--- a/worker/src/config.rs
+++ b/worker/src/config.rs
@@ -9,6 +9,8 @@ pub struct ConfigFile {
     pub signup_secret: Option<String>,
     // this option is deprecated, use diffoscope.enabled instead
     #[serde(default)]
+    pub supported_backends: Vec<String>,
+    #[serde(default)]
     pub gen_diffoscope: bool,
     #[serde(default)]
     pub build: Build,

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -96,7 +96,9 @@ async fn spawn_rebuilder_script_with_heartbeat<'a>(client: &Client, distro: &Dis
 
 async fn rebuild(client: &Client, config: &config::ConfigFile) -> Result<()> {
     info!("Requesting work from rebuilderd...");
-    match client.pop_queue(&WorkQuery {}).await? {
+    match client.pop_queue(&WorkQuery {
+        supported_backends: config.supported_backends.clone(),
+    }).await? {
         JobAssignment::Nothing => {
             info!("No pending tasks, sleeping for {}s...", IDLE_DELAY);
             time::sleep(Duration::from_secs(IDLE_DELAY)).await;

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -163,7 +163,9 @@ async fn main() -> Result<()> {
         .context("Failed to load config file")?;
 
     let cookie = find_auth_cookie().ok();
-    debug!("attempt to load auth cookie resulted in: {:?}",cookie);
+    if cookie.is_some() {
+        debug!("Successfully loaded auth cookie");
+    }
 
     if let Some(name) = args.name {
         setup::run(&name)


### PR DESCRIPTION
This is revising the docker-compose stack into a more usable development setup (also adding instructions on how to do basic development).

Since not every worker can rebuild the any other packages we're now tracking which distro needs to be supported.

This is only informal right now to not break any existing setups.