### PR TITLE
Refactor rebuilder-backend configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 /target
 **/*.rs.bk
 contrib/*.1
-/worker/rebuilder.key
+rebuilder.key
+rebuilder.v2.key
 /worker/build/
 /worker/cache/
 /data/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,9 +359,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
@@ -967,9 +967,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f3675cfef6a30c8031cf9e6493ebdc3bb3272a3fea3923c4210d1830e6a472"
+checksum = "6c06815895acec637cd6ed6e9662c935b866d20a106f8361892893a7d9234964"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
@@ -979,7 +979,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.11.0",
+ "tokio 1.12.0",
  "tokio-util 0.6.8",
  "tracing",
 ]
@@ -1021,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
+checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
@@ -1069,7 +1069,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.4",
+ "h2 0.3.6",
  "http",
  "http-body",
  "httparse",
@@ -1077,7 +1077,7 @@ dependencies = [
  "itoa",
  "pin-project-lite 0.2.7",
  "socket2 0.4.2",
- "tokio 1.11.0",
+ "tokio 1.12.0",
  "tower-service",
  "tracing",
  "want",
@@ -1092,7 +1092,7 @@ dependencies = [
  "bytes 1.1.0",
  "hyper",
  "native-tls",
- "tokio 1.11.0",
+ "tokio 1.12.0",
  "tokio-native-tls",
 ]
 
@@ -1151,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
+checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1233,9 +1233,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.102"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
+checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1347,9 +1347,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "minimal-lexical"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c835948974f68e0bd58636fc6c5b1fbff7b297e3046f11b3b3c18bbac012c6d"
+checksum = "9c64630dcdd71f1a64c435f54885086a0de5d6a12d104d69b165fb7d5286d677"
 
 [[package]]
 name = "miniz_oxide"
@@ -1456,9 +1456,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7555d6c7164cc913be1ce7f95cbecdabda61eb2ccd89008524af306fb7f5031"
+checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
 dependencies = [
  "bitflags",
  "cc",
@@ -1550,9 +1550,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.66"
+version = "0.9.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1996d2d305e561b70d1ee0c53f1542833f4e1ac6ce9a6708b6ff2738ca67dc82"
+checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
 dependencies = [
  "autocfg",
  "cc",
@@ -1677,9 +1677,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
 
 [[package]]
 name = "ppv-lite86"
@@ -1740,9 +1740,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
@@ -1861,7 +1861,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "tar",
- "tokio 1.11.0",
+ "tokio 1.12.0",
  "toml",
  "tree_magic_mini",
  "url",
@@ -1915,7 +1915,7 @@ dependencies = [
  "rebuilderd-common",
  "structopt",
  "tempfile",
- "tokio 1.11.0",
+ "tokio 1.12.0",
 ]
 
 [[package]]
@@ -1934,7 +1934,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "tempfile",
- "tokio 1.11.0",
+ "tokio 1.12.0",
  "toml",
  "url",
 ]
@@ -2010,7 +2010,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.11.0",
+ "tokio 1.12.0",
  "tokio-native-tls",
  "url",
  "wasm-bindgen",
@@ -2113,9 +2113,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "2.3.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
+checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2246,9 +2246,9 @@ checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "socket2"
@@ -2385,9 +2385,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "a4eac2e6c19f5c3abc0c229bea31ff0b9b091c7b14990e8924b92902a303a0c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2516,9 +2516,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5241dd6f21443a3606b432718b166d3cedc962fd4b8bea54a8bc7f514ebda986"
+checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2551,9 +2551,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
+checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
 dependencies = [
  "autocfg",
  "bytes 1.1.0",
@@ -2570,9 +2570,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+checksum = "154794c8f499c2619acd19e839294703e9e32e7630ef5f46ea80d4ef0fbee5eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2586,7 +2586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.11.0",
+ "tokio 1.12.0",
 ]
 
 [[package]]
@@ -2614,7 +2614,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.2.7",
- "tokio 1.11.0",
+ "tokio 1.12.0",
 ]
 
 [[package]]
@@ -2646,9 +2646,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46125608c26121c81b0c6d693eab5a420e416da7e43c426d2e8f7df8da8a3acf"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
 ]

--- a/common/src/api.rs
+++ b/common/src/api.rs
@@ -1,7 +1,7 @@
 use chrono::prelude::*;
 use crate::config::ConfigFile;
 use crate::errors::*;
-use crate::{Distro, PkgRelease, PkgGroup, Status};
+use crate::{PkgRelease, PkgGroup, Status};
 use crate::auth;
 use reqwest::{Client as HttpClient, RequestBuilder};
 use serde::{Serialize, Deserialize};
@@ -272,7 +272,7 @@ pub enum JobAssignment {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SuiteImport {
-    pub distro: Distro,
+    pub distro: String,
     pub suite: String,
     pub pkgs: Vec<PkgGroup>,
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -38,7 +38,8 @@ pub struct PkgRelease {
     pub distro: String,
     pub suite: String,
     pub architecture: String,
-    pub url: String,
+    pub artifact_url: String,
+    pub input_url: Option<String>,
     pub build_id: Option<i32>,
     pub built_at: Option<NaiveDateTime>,
     pub has_diffoscope: bool,
@@ -47,7 +48,7 @@ pub struct PkgRelease {
 }
 
 impl PkgRelease {
-    pub fn new(name: String, version: String, distro: String, suite: String, architecture: String, url: String) -> PkgRelease {
+    pub fn new(name: String, version: String, distro: String, suite: String, architecture: String, artifact_url: String, input_url: Option<String>) -> PkgRelease {
         PkgRelease {
             name,
             version,
@@ -55,7 +56,8 @@ impl PkgRelease {
             distro,
             suite,
             architecture,
-            url,
+            artifact_url,
+            input_url,
             build_id: None,
             built_at: None,
             has_diffoscope: false,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -16,10 +16,18 @@ pub mod utils;
 #[derive(Debug, Clone, Copy, PartialEq, Display, EnumString, AsRefStr, Serialize, Deserialize)]
 #[strum(serialize_all = "kebab-case")]
 #[serde(rename_all = "kebab-case")]
-pub enum Distro {
+pub enum VersionCmp {
+    Basic,
     Debian,
-    Archlinux,
-    Tails,
+}
+
+impl VersionCmp {
+    pub fn detect_from_distro(distro: &str) -> VersionCmp {
+        match distro {
+            "debian" => VersionCmp::Debian,
+            _ => VersionCmp::Basic,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -39,12 +47,12 @@ pub struct PkgRelease {
 }
 
 impl PkgRelease {
-    pub fn new(name: String, version: String, distro: Distro, suite: String, architecture: String, url: String) -> PkgRelease {
+    pub fn new(name: String, version: String, distro: String, suite: String, architecture: String, url: String) -> PkgRelease {
         PkgRelease {
             name,
             version,
             status: Status::Unknown,
-            distro: distro.to_string(),
+            distro,
             suite,
             architecture,
             url,
@@ -77,11 +85,11 @@ pub struct PkgArtifact {
 }
 
 impl PkgGroup {
-    pub fn new(base: String, version: String, distro: Distro, suite: String, architecture: String, input: Option<String>) -> PkgGroup {
+    pub fn new(base: String, version: String, distro: String, suite: String, architecture: String, input: Option<String>) -> PkgGroup {
         PkgGroup {
             base,
             version,
-            distro: distro.to_string(),
+            distro,
             suite,
             architecture,
             input,

--- a/contrib/confs/rebuilderd-sync.conf
+++ b/contrib/confs/rebuilderd-sync.conf
@@ -24,6 +24,14 @@ architectures = ["amd64"]
 releases = ["buster", "sid"]
 source = "http://deb.debian.org/debian"
 
+[profile."debian-anarchism"]
+distro = "debian"
+suite = "main"
+architectures = ["amd64"]
+releases = ["sid"]
+pkgs = ["anarchism"]
+source = "http://deb.debian.org/debian"
+
 [profile."tails"]
 distro = "tails"
 suite = "stable"

--- a/contrib/confs/rebuilderd-worker.conf
+++ b/contrib/confs/rebuilderd-worker.conf
@@ -22,3 +22,12 @@ enabled = false
 ## Set a maximum diffoscope output limit in bytes (default: none).
 ## When reaching this limit, diffoscope is terminated and the output is truncated.
 max_bytes = 41943040 # 40 MiB
+
+[backend."archlinux"]
+path = "/usr/libexec/rebuilderd/rebuild-archlinux.sh"
+
+[backend."debian"]
+path = "/usr/libexec/rebuilderd/rebuild-debian.sh"
+
+[backend."tails"]
+path = "/usr/libexec/rebuilderd/rebuild-tails.sh"

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -11,6 +11,9 @@ struct Args {
     /// Verbose logging
     #[structopt(short)]
     verbose: bool,
+    /// Load and print a config
+    #[structopt(long)]
+    check_config: bool,
     /// Configuration file path
     #[structopt(short, long)]
     config: Option<PathBuf>,

--- a/daemon/src/models/package.rs
+++ b/daemon/src/models/package.rs
@@ -180,7 +180,8 @@ impl Package {
             version: self.version,
             status: self.status.parse()?,
             suite: self.suite,
-            url: self.url,
+            artifact_url: self.url,
+            input_url: None, // TODO
             build_id: self.build_id,
             built_at: self.built_at,
             has_diffoscope: self.has_diffoscope,
@@ -234,7 +235,7 @@ impl NewPackage {
             distro: distro.to_string(),
             suite: pkg.suite,
             architecture: pkg.architecture,
-            url: pkg.url,
+            url: pkg.artifact_url,
             build_id: None,
             built_at: None,
             has_diffoscope: false,

--- a/daemon/src/models/package.rs
+++ b/daemon/src/models/package.rs
@@ -1,7 +1,7 @@
 use chrono::{Utc, NaiveDateTime, Duration};
 use crate::schema::*;
 use diesel::prelude::*;
-use rebuilderd_common::{PkgRelease, Distro, Status};
+use rebuilderd_common::{PkgRelease, Status};
 use rebuilderd_common::api::{Rebuild, BuildStatus};
 use rebuilderd_common::errors::*;
 
@@ -225,7 +225,7 @@ impl NewPackage {
         Ok(())
     }
 
-    pub fn from_api(distro: Distro, base_id: i32, pkg: PkgRelease) -> NewPackage {
+    pub fn from_api(distro: String, base_id: i32, pkg: PkgRelease) -> NewPackage {
         NewPackage {
             base_id: Some(base_id),
             name: pkg.name,

--- a/daemon/src/sync.rs
+++ b/daemon/src/sync.rs
@@ -1,7 +1,7 @@
 use crate::models;
 use crate::versions::PkgVerCmp;
 use diesel::SqliteConnection;
-use rebuilderd_common::PkgRelease;
+use rebuilderd_common::{PkgRelease, VersionCmp};
 use rebuilderd_common::api::*;
 use rebuilderd_common::errors::*;
 use std::cmp::Ordering;
@@ -28,7 +28,7 @@ fn insert_pkgbases(import: &mut SuiteImport, connection: &SqliteConnection) -> R
             import_pkgs.push((base.base.clone(), PkgRelease::new(
                 artifact.name,
                 base.version.clone(),
-                import.distro,
+                import.distro.clone(),
                 base.suite.clone(),
                 base.architecture.clone(),
                 artifact.url,
@@ -109,15 +109,18 @@ fn sync(import: &mut SuiteImport, connection: &SqliteConnection) -> Result<()> {
     let mut updated_pkgs = HashMap::<_, (String, models::Package)>::new();
     let mut deleted_pkgs = pkgs.clone();
 
+    // TODO: instead of bumping versions we should just drop the old ones so we don't need version_cmp
+    let version_cmp = VersionCmp::detect_from_distro(&import.distro);
+
     for (base, pkg) in import_pkgs.drain(..) {
         deleted_pkgs.remove_entry(&pkg.name);
 
         if let Some((_, cur)) = new_pkgs.get_mut(&pkg.name) {
-            cur.bump_package(&import.distro, &pkg)?;
+            cur.bump_package(&version_cmp, &pkg)?;
         } else if let Some((_, cur)) = updated_pkgs.get_mut(&pkg.name) {
-            cur.bump_package(&import.distro, &pkg)?;
+            cur.bump_package(&version_cmp, &pkg)?;
         } else if let Some(old) = pkgs.get_mut(&pkg.name) {
-            if old.bump_package(&import.distro, &pkg)? == Ordering::Greater {
+            if old.bump_package(&version_cmp, &pkg)? == Ordering::Greater {
                 updated_pkgs.insert(pkg.name, (base, old.clone()));
             }
         } else {
@@ -143,7 +146,7 @@ fn sync(import: &mut SuiteImport, connection: &SqliteConnection) -> Result<()> {
         }
         let pkgbase = &pkgbases[0];
 
-        insert_pkgs.push(models::NewPackage::from_api(import.distro, pkgbase.id, v));
+        insert_pkgs.push(models::NewPackage::from_api(import.distro.clone(), pkgbase.id, v));
     }
 
     for insert_pkgs in insert_pkgs.chunks(1_000) {

--- a/daemon/src/sync.rs
+++ b/daemon/src/sync.rs
@@ -32,6 +32,7 @@ fn insert_pkgbases(import: &mut SuiteImport, connection: &SqliteConnection) -> R
                 base.suite.clone(),
                 base.architecture.clone(),
                 artifact.url,
+                base.input.clone(),
             )));
         }
         let key = format!("{}-{}", base.base, base.version);

--- a/daemon/src/versions.rs
+++ b/daemon/src/versions.rs
@@ -1,15 +1,15 @@
 use rebuilderd_common::errors::*;
-use rebuilderd_common::Distro;
+use rebuilderd_common::VersionCmp;
 use std::process::Command;
 use crate::models;
 use rebuilderd_common::PkgRelease;
 use std::cmp::Ordering;
 
-pub fn cmp(distro: &Distro, old: &str, new: &str) -> Result<Ordering> {
+// TOOD: this needs to be more configurable
+pub fn cmp(distro: &VersionCmp, old: &str, new: &str) -> Result<Ordering> {
     match distro {
-        Distro::Archlinux => cmp_basic(old, new),
-        Distro::Debian => cmp_debian(old, new),
-        Distro::Tails => cmp_basic(old, new),
+        VersionCmp::Basic => cmp_basic(old, new),
+        VersionCmp::Debian => cmp_debian(old, new),
     }
 }
 
@@ -44,7 +44,7 @@ pub fn cmp_debian(old: &str, new: &str) -> Result<Ordering> {
 }
 
 pub trait PkgVerCmp {
-    fn bump_package(&mut self, distro: &Distro, new: &PkgRelease) -> Result<Ordering> {
+    fn bump_package(&mut self, distro: &VersionCmp, new: &PkgRelease) -> Result<Ordering> {
         let ord = cmp(distro, self.version(), &new.version)?;
         if ord == Ordering::Greater {
             self.apply_fields(new);

--- a/daemon/src/versions.rs
+++ b/daemon/src/versions.rs
@@ -65,7 +65,7 @@ impl PkgVerCmp for models::Package {
     fn apply_fields(&mut self, new: &PkgRelease) {
         self.version = new.version.clone();
         self.architecture = new.architecture.clone();
-        self.url = new.url.clone();
+        self.url = new.artifact_url.clone();
     }
 }
 
@@ -76,6 +76,6 @@ impl PkgVerCmp for PkgRelease {
 
     fn apply_fields(&mut self, new: &PkgRelease) {
         self.version = new.version.clone();
-        self.url = new.url.clone();
+        self.artifact_url = new.artifact_url.clone();
     }
 }

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -2,7 +2,6 @@ use crate::args::Args;
 use colored::Colorize;
 use env_logger::Env;
 use rebuilderd::config::Config;
-use rebuilderd_common::Distro;
 use rebuilderd_common::{PkgGroup, PkgArtifact, PkgRelease};
 use rebuilderd_common::Status;
 use rebuilderd_common::api::*;
@@ -29,7 +28,7 @@ async fn list_pkgs(client: &Client) -> Result<Vec<PkgRelease>> {
 }
 
 async fn initial_import(client: &Client) -> Result<()> {
-    let distro = Distro::Archlinux;
+    let distro = "archlinux".to_string();
     let suite = "core".to_string();
     let architecture = "x86_64".to_string();
 
@@ -37,7 +36,7 @@ async fn initial_import(client: &Client) -> Result<()> {
     let mut group = PkgGroup::new(
         "pkgbase".to_string(),
         "1.4.5-1".to_string(),
-        Distro::Archlinux,
+        distro.clone(),
         suite.clone(),
         architecture.clone(),
         None,

--- a/tools/src/args.rs
+++ b/tools/src/args.rs
@@ -1,4 +1,4 @@
-use rebuilderd_common::{Distro, Status};
+use rebuilderd_common::Status;
 use rebuilderd_common::errors::*;
 use glob::Pattern;
 use std::io::stdout;
@@ -68,13 +68,13 @@ pub struct PkgsSyncProfile {
 
 #[derive(Debug, StructOpt)]
 pub struct PkgsSyncStdin {
-    pub distro: Distro,
+    pub distro: String,
     pub suite: String,
 }
 
 #[derive(Debug, StructOpt)]
 pub struct PkgsSync {
-    pub distro: Distro,
+    pub distro: String,
     pub suite: String,
     pub source: String,
     #[structopt(long="architecture")]

--- a/tools/src/config.rs
+++ b/tools/src/config.rs
@@ -1,4 +1,3 @@
-use rebuilderd_common::Distro;
 use rebuilderd_common::errors::*;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -23,7 +22,7 @@ impl SyncConfigFile {
 
 #[derive(Debug, Deserialize)]
 pub struct SyncProfile {
-    pub distro: Distro,
+    pub distro: String,
     pub suite: String,
     #[serde(default)]
     pub releases: Vec<String>,

--- a/tools/src/main.rs
+++ b/tools/src/main.rs
@@ -3,7 +3,6 @@ use crate::args::*;
 use crate::config::SyncConfigFile;
 use env_logger::Env;
 use glob::Pattern;
-use rebuilderd_common::Distro;
 use rebuilderd_common::api::*;
 use rebuilderd_common::errors::*;
 use rebuilderd_common::utils;
@@ -37,10 +36,11 @@ fn print_json<S: Serialize>(x: &S) -> Result<()> {
 }
 
 pub async fn sync(client: &Client, sync: PkgsSync) -> Result<()> {
-    let mut pkgs = match sync.distro {
-        Distro::Archlinux => schedule::archlinux::sync(&sync).await?,
-        Distro::Debian => schedule::debian::sync(&sync).await?,
-        Distro::Tails => schedule::tails::sync(&sync).await?,
+    let mut pkgs = match sync.distro.as_str() {
+        "archlinux" => schedule::archlinux::sync(&sync).await?,
+        "debian" => schedule::debian::sync(&sync).await?,
+        "tails" => schedule::tails::sync(&sync).await?,
+        unknown => bail!("No integrated sync for {:?}, use sync-stdin instead", unknown),
     };
     pkgs.sort_by(|a, b| a.base.cmp(&b.base));
 

--- a/tools/src/main.rs
+++ b/tools/src/main.rs
@@ -189,7 +189,7 @@ async fn main() -> Result<()> {
                         status_str,
                         pkg_str,
                         info,
-                        pkg.url,
+                        pkg.artifact_url,
                     ).is_err() {
                         break;
                     }

--- a/tools/src/schedule/archlinux.rs
+++ b/tools/src/schedule/archlinux.rs
@@ -2,7 +2,7 @@ use crate::args::PkgsSync;
 use crate::decompress;
 use crate::schedule::{Pkg, fetch_url_or_path};
 use nom::bytes::complete::take_till;
-use rebuilderd_common::{PkgGroup, PkgArtifact, Distro};
+use rebuilderd_common::{PkgGroup, PkgArtifact};
 use rebuilderd_common::errors::*;
 use std::collections::HashMap;
 use std::convert::TryInto;
@@ -160,7 +160,7 @@ pub async fn sync(sync: &PkgsSync) -> Result<Vec<PkgGroup>> {
                 let mut group = PkgGroup::new(
                     pkg.base.clone(),
                     pkg.version,
-                    Distro::Archlinux,
+                    "archlinux".to_string(),
                     sync.suite.to_string(),
                     pkg.architecture,
                     None,

--- a/tools/src/schedule/debian.rs
+++ b/tools/src/schedule/debian.rs
@@ -1,7 +1,7 @@
 use crate::args::PkgsSync;
 use crate::schedule::{Pkg, fetch_url_or_path};
 use lzma::LzmaReader;
-use rebuilderd_common::{PkgGroup, PkgArtifact, Distro};
+use rebuilderd_common::{PkgGroup, PkgArtifact};
 use rebuilderd_common::errors::*;
 use std::collections::HashMap;
 use std::convert::TryInto;
@@ -166,7 +166,7 @@ pub async fn sync(sync: &PkgsSync) -> Result<Vec<PkgGroup>> {
                 let mut group = PkgGroup::new(
                     pkg.base.clone(),
                     pkg.version.clone(),
-                    Distro::Debian,
+                    "debian".to_string(),
                     sync.suite.to_string(),
                     arch.clone(),
                     Some(url),

--- a/tools/src/schedule/mod.rs
+++ b/tools/src/schedule/mod.rs
@@ -51,7 +51,6 @@ pub mod tails;
 #[cfg(test)]
 mod tests {
     use crate::schedule::archlinux::ArchPkg;
-    use rebuilderd_common::Distro;
     use super::*;
 
     struct Filter {
@@ -68,7 +67,7 @@ mod tests {
 
     fn gen_filter(f: Filter) -> PkgsSync {
         PkgsSync {
-            distro: Distro::Archlinux,
+            distro: "archlinux".to_string(),
             suite: "community".to_string(),
             architectures: vec!["x86_64".to_string()],
             source: "https://ftp.halifax.rwth-aachen.de/archlinux/$repo/os/$arch".to_string(),

--- a/tools/src/schedule/tails.rs
+++ b/tools/src/schedule/tails.rs
@@ -1,6 +1,6 @@
 use crate::args::PkgsSync;
 use url::Url;
-use rebuilderd_common::{PkgGroup, PkgArtifact, Distro};
+use rebuilderd_common::{PkgGroup, PkgArtifact};
 use rebuilderd_common::errors::*;
 use regex::Regex;
 
@@ -35,7 +35,7 @@ pub async fn sync(sync: &PkgsSync) -> Result<Vec<PkgGroup>> {
     let mut group = PkgGroup::new(
         "tails".to_string(),
         version.to_string(),
-        Distro::Tails,
+        "tails".to_string(),
         sync.suite.to_string(),
         "amd64".to_string(),
         None,

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -31,5 +31,5 @@ url = "2.1.1"
 tokio = { version="1", features=["macros", "rt-multi-thread", "fs", "io-util", "process", "io-std", "time"] }
 futures-util = "0.3.7"
 futures = "0.3.7"
-nix = "0.22"
+nix = "0.23"
 in-toto = "0.1.1"

--- a/worker/Dockerfile.alpine
+++ b/worker/Dockerfile.alpine
@@ -13,4 +13,5 @@ RUN --mount=type=cache,target=/var/cache/buildkit \
 FROM alpine:3.14
 RUN apk add --no-cache libgcc openssl
 COPY --from=0 /rebuilderd-worker /usr/local/bin/
+ENV REBUILDERD_WORKER_BACKEND=alpine=/usr/local/libexec/rebuilderd/rebuild-alpine.sh
 ENTRYPOINT ["rebuilderd-worker"]

--- a/worker/Dockerfile.archlinux
+++ b/worker/Dockerfile.archlinux
@@ -15,4 +15,5 @@ COPY --from=0 \
     /usr/src/rebuilderd/worker/rebuilder-archlinux.sh \
     /usr/local/libexec/rebuilderd/
 COPY --from=0 /rebuilderd-worker /usr/local/bin/
+ENV REBUILDERD_WORKER_BACKEND=archlinux=/usr/local/libexec/rebuilderd/rebuild-archlinux.sh
 ENTRYPOINT ["rebuilderd-worker"]

--- a/worker/Dockerfile.debian
+++ b/worker/Dockerfile.debian
@@ -15,4 +15,5 @@ COPY --from=0 \
     /usr/src/rebuilderd/worker/rebuilder-debian.sh \
     /usr/local/libexec/rebuilderd/
 COPY --from=0 /rebuilderd-worker /usr/local/bin/
+ENV REBUILDERD_WORKER_BACKEND=debian=/usr/local/libexec/rebuilderd/rebuild-debian.sh
 ENTRYPOINT ["rebuilderd-worker"]

--- a/worker/Dockerfile.tails
+++ b/worker/Dockerfile.tails
@@ -16,4 +16,5 @@ COPY --from=0 \
     /usr/src/rebuilderd/worker/rebuilder-tails.sh \
     /usr/local/libexec/rebuilderd/
 COPY --from=0 /rebuilderd-worker /usr/local/bin/
+ENV REBUILDERD_WORKER_BACKEND=tails=/usr/local/libexec/rebuilderd/rebuild-tails.sh
 ENTRYPOINT ["rebuilderd-worker"]

--- a/worker/src/args.rs
+++ b/worker/src/args.rs
@@ -29,8 +29,13 @@ pub enum SubCommand {
 
 #[derive(Debug, StructOpt)]
 pub struct Build {
+    /// Selects the right build profile from the configuration
     pub distro: String,
-    pub input: String,
+    /// The pre-built artifact that should be reproduced
+    pub artifact: String,
+    /// Pass a different input file to the rebuilder backend
+    #[structopt(long)]
+    pub input: Option<String>,
     /// Use a specific rebuilder script instead of the default
     #[structopt(long)]
     pub script_location: Option<PathBuf>,

--- a/worker/src/args.rs
+++ b/worker/src/args.rs
@@ -1,0 +1,51 @@
+use structopt::StructOpt;
+use structopt::clap::AppSettings;
+use std::path::PathBuf;
+
+#[derive(Debug, StructOpt)]
+#[structopt(global_settings = &[AppSettings::ColoredHelp])]
+pub struct Args {
+    #[structopt(subcommand)]
+    pub subcommand: SubCommand,
+    #[structopt(short, long)]
+    pub name: Option<String>,
+    #[structopt(short, long, global = true, env = "REBUILDERD_WORKER_CONFIG")]
+    pub config: Option<PathBuf>,
+    #[structopt(long="backend", global = true, env = "REBUILDERD_WORKER_BACKEND")]
+    pub backends: Vec<String>,
+}
+
+#[derive(Debug, StructOpt)]
+pub enum SubCommand {
+    /// Rebuild an individual package
+    Build(Build),
+    /// Connect to a central rebuilderd daemon for work
+    Connect(Connect),
+    /// Invoke diffoscope similar to how a rebuilder would invoke it
+    Diffoscope(Diffoscope),
+    /// Load and print a config
+    CheckConfig,
+}
+
+#[derive(Debug, StructOpt)]
+pub struct Build {
+    pub distro: String,
+    pub input: String,
+    /// Use a specific rebuilder script instead of the default
+    #[structopt(long)]
+    pub script_location: Option<PathBuf>,
+    /// Use diffoscope to generate a diff
+    #[structopt(long)]
+    pub gen_diffoscope: bool,
+}
+
+#[derive(Debug, StructOpt)]
+pub struct Connect {
+    pub endpoint: Option<String>,
+}
+
+#[derive(Debug, StructOpt)]
+pub struct Diffoscope {
+    pub a: PathBuf,
+    pub b: PathBuf,
+}

--- a/worker/src/args.rs
+++ b/worker/src/args.rs
@@ -32,10 +32,10 @@ pub struct Build {
     /// Selects the right build profile from the configuration
     pub distro: String,
     /// The pre-built artifact that should be reproduced
-    pub artifact: String,
+    pub artifact_url: String,
     /// Pass a different input file to the rebuilder backend
     #[structopt(long)]
-    pub input: Option<String>,
+    pub input_url: Option<String>,
     /// Use a specific rebuilder script instead of the default
     #[structopt(long)]
     pub script_location: Option<PathBuf>,

--- a/worker/src/config.rs
+++ b/worker/src/config.rs
@@ -1,24 +1,23 @@
+use crate::args::Args;
 use rebuilderd_common::errors::*;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::PathBuf;
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ConfigFile {
     pub endpoint: Option<String>,
     pub signup_secret: Option<String>,
-    // this option is deprecated, use diffoscope.enabled instead
-    #[serde(default)]
-    pub supported_backends: Vec<String>,
-    #[serde(default)]
-    pub gen_diffoscope: bool,
     #[serde(default)]
     pub build: Build,
     #[serde(default)]
     pub diffoscope: Diffoscope,
+    #[serde(default, rename="backend")]
+    pub backends: HashMap<String, Backend>,
 }
 
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Build {
     pub timeout: Option<u64>,
     pub max_bytes: Option<usize>,
@@ -26,7 +25,7 @@ pub struct Build {
     pub silent: bool,
 }
 
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Diffoscope {
     #[serde(default)]
     pub enabled: bool,
@@ -36,20 +35,36 @@ pub struct Diffoscope {
     pub max_bytes: Option<usize>,
 }
 
-pub fn load(path: Option<&Path>) -> Result<ConfigFile> {
-    let path = path.unwrap_or_else(|| Path::new("/etc/rebuilderd-worker.conf"));
-    if path.exists() {
-        let buf = fs::read(path)
-            .with_context(|| anyhow!("Failed to open {:?}", path))?;
-        let mut conf = toml::from_slice::<ConfigFile>(&buf)?;
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Backend {
+    pub path: PathBuf,
+}
 
-        if conf.gen_diffoscope {
-            warn!("Option gen_diffoscope is deprecated, use diffoscope.enabled instead");
-            conf.diffoscope.enabled = true;
-        }
-
-        Ok(conf)
+pub fn load(args: &Args) -> Result<ConfigFile> {
+    let path = if let Some(path) = args.config.as_ref() {
+        path.to_owned()
     } else {
-        Ok(ConfigFile::default())
+        let path = PathBuf::from("/etc/rebuilderd-worker.conf");
+        if path.exists() {
+            warn!("Using the implicit `-c /etc/rebuilderd-worker.conf` is going to be removed in the future");
+            path
+        } else {
+            return Ok(ConfigFile::default());
+        }
+    };
+
+    let buf = fs::read(&path)
+        .with_context(|| anyhow!("Failed to open {:?}", path))?;
+    let mut conf = toml::from_slice::<ConfigFile>(&buf)?;
+
+    for backend in &args.backends {
+        let (key, path) = backend.split_once('=')
+            .ok_or_else(|| anyhow!("Invalid argument, expected format is --backend distro=/path/to/script"))?;
+
+        conf.backends.insert(key.into(), Backend {
+            path: path.into(),
+        });
     }
+
+    Ok(conf)
 }

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -66,7 +66,7 @@ async fn rebuild(client: &Client, privkey: &PrivateKey, config: &config::ConfigF
 
             let backend = config.backends.get(&rb.package.distro)
                 .cloned()
-                .ok_or_else(|| anyhow!("No backend configured in config file"))?;
+                .ok_or_else(|| anyhow!("No backend for {:?} configured", rb.package.distro))?;
 
             let rebuild = match spawn_rebuilder_script_with_heartbeat(client, privkey, backend, &rb, config).await {
                 Ok(res) => {

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -30,13 +30,15 @@ async fn spawn_rebuilder_script_with_heartbeat<'a>(client: &Client, privkey: &Pr
     let input = item.package.url.to_string();
 
     let ctx = Context {
+        artifact_url: &input,
+        input_url: None,
         backend,
         build: config.build.clone(),
         diffoscope: config.diffoscope.clone(),
         privkey,
     };
 
-    let mut rebuild = Box::pin(rebuild::rebuild(&ctx, &input));
+    let mut rebuild = Box::pin(rebuild::rebuild(&ctx));
     loop {
         select! {
             res = &mut rebuild => {
@@ -172,11 +174,13 @@ async fn main() -> Result<()> {
             };
 
             let res = rebuild::rebuild(&Context {
+                artifact_url: &build.artifact,
+                input_url: None,
                 backend,
                 build: config::Build::default(),
                 diffoscope,
                 privkey: &profile.privkey,
-            }, &build.input).await?;
+            }).await?;
 
             debug!("rebuild result object is {:?}", res);
 

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -27,11 +27,9 @@ pub mod rebuild;
 pub mod setup;
 
 async fn spawn_rebuilder_script_with_heartbeat<'a>(client: &Client, privkey: &PrivateKey, backend: config::Backend, item: &QueueItem, config: &config::ConfigFile) -> Result<Rebuild> {
-    let input = item.package.url.to_string();
-
     let ctx = Context {
-        artifact_url: &input,
-        input_url: None,
+        artifact_url: item.package.artifact_url.clone(),
+        input_url: item.package.input_url.clone(),
         backend,
         build: config.build.clone(),
         diffoscope: config.diffoscope.clone(),
@@ -174,15 +172,15 @@ async fn main() -> Result<()> {
             };
 
             let res = rebuild::rebuild(&Context {
-                artifact_url: &build.artifact,
-                input_url: None,
+                artifact_url: build.artifact_url,
+                input_url: build.input_url,
                 backend,
                 build: config::Build::default(),
                 diffoscope,
                 privkey: &profile.privkey,
             }).await?;
 
-            debug!("rebuild result object is {:?}", res);
+            trace!("rebuild result object is {:?}", res);
 
             if res.status == BuildStatus::Good {
                 info!("Package verified successfully");

--- a/worker/src/rebuild.rs
+++ b/worker/src/rebuild.rs
@@ -16,8 +16,8 @@ use tokio::fs::File;
 use tokio::io::AsyncReadExt;
 
 pub struct Context<'a> {
-    pub artifact_url: &'a str,
-    pub input_url: Option<&'a str>,
+    pub artifact_url: String,
+    pub input_url: Option<String>,
     pub backend: config::Backend,
     pub build: config::Build,
     pub diffoscope: config::Diffoscope,
@@ -98,7 +98,7 @@ pub async fn rebuild(ctx: &Context<'_>) -> Result<Rebuild> {
         .context("Failed to create out/ temp dir")?;
 
     // download
-    let artifact_filename = download(ctx.artifact_url, &inputs_dir)
+    let artifact_filename = download(&ctx.artifact_url, &inputs_dir)
         .await
         .with_context(|| anyhow!("Failed to download original package from {:?}", ctx.artifact_url))?;
     let artifact_path = inputs_dir.join(&artifact_filename);


### PR DESCRIPTION
This prepares a switch from the `Distro` enum to an opaque string. The code that automatically detects the right rebuilder-backend location (in eg. `/usr/libexec/rebuilderd/`) has been removed and instead the systems supported by the worker need to be explicitly configured.

Together with the `rebuildctl pkgs sync-stdin` command this should allow building your own integrations with rebuilderd.