### PR TITLE
Add missing runtime dependencies to docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:alpine3.14
 ENV RUSTFLAGS="-C target-feature=-crt-static"
 WORKDIR /usr/src/rebuilderd
-RUN apk add --no-cache musl-dev openssl-dev sqlite-dev xz-dev zstd-dev
+RUN apk add --no-cache musl-dev openssl-dev shared-mime-info sqlite-dev xz-dev zstd-dev
 COPY . .
 RUN --mount=type=cache,target=/var/cache/buildkit \
     CARGO_HOME=/var/cache/buildkit/cargo \
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/var/cache/buildkit \
         /var/cache/buildkit/target/release/rebuildctl /
 
 FROM alpine:3.14
-RUN apk add --no-cache libgcc openssl dpkg sqlite-libs xz zstd-libs
+RUN apk add --no-cache libgcc openssl shared-mime-info sqlite-libs xz zstd-libs
 COPY --from=0 \
     /rebuilderd /rebuildctl \
     /usr/local/bin/

--- a/worker/Dockerfile.debian
+++ b/worker/Dockerfile.debian
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/var/cache/buildkit \
     cp -v /var/cache/buildkit/debian/target/release/rebuilderd-worker /
 
 FROM debian:bullseye
-RUN apt-get update && apt install -y libssl-dev git mmdebstrap \
+RUN apt-get update && apt install -y libssl-dev git mmdebstrap diffoscope \
     python3-apt python3-dateutil python3-requests python3-rstr python3-setuptools python3-httpx python3-tenacity \
     debian-keyring debian-archive-keyring debian-ports-archive-keyring
 # this is a temporary solution


### PR DESCRIPTION
Adds the missing `shared-mime-info` runtime dependency to the docker image.

Resolves #92