### PR TITLE
Generate diffoscope from artifact_path, not input_path

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -8,12 +8,9 @@ use crate::dashboard::DashboardState;
 use diesel::RunQueryDsl;
 use rebuilderd_common::api::{BuildReport, SuiteImport};
 use rebuilderd_common::errors::*;
-use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::Duration;
-use structopt::StructOpt;
-use structopt::clap::AppSettings;
 
 pub mod api;
 pub mod auth;
@@ -24,17 +21,6 @@ pub mod schema;
 pub mod sync;
 pub mod models;
 pub mod web;
-
-#[derive(Debug, StructOpt)]
-#[structopt(global_settings = &[AppSettings::ColoredHelp])]
-struct Args {
-    /// Verbose logging
-    #[structopt(short)]
-    verbose: bool,
-    /// Configuration file path
-    #[structopt(short, long)]
-    config: Option<PathBuf>,
-}
 
 pub async fn run_config(config: Config) -> Result<()> {
     let pool = db::setup_pool("rebuilderd.db")?;

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -36,5 +36,10 @@ async fn main() -> Result<()> {
 
     dotenv::dotenv().ok();
     let config = config::load(args.config.as_deref())?;
-    rebuilderd::run_config(config).await
+    if args.check_config {
+        println!("{:#?}", config);
+    } else {
+        rebuilderd::run_config(config).await?;
+    }
+    Ok(())
 }

--- a/tools/src/schedule/debian.rs
+++ b/tools/src/schedule/debian.rs
@@ -61,12 +61,12 @@ pub enum VersionConstraint {
 
 #[derive(Debug)]
 pub struct DebianSourcePkg {
-    base: String,
-    binary: Vec<String>,
-    version: String,
-    directory: String,
-    architecture: String,
-    uploaders: Vec<String>,
+    pub base: String,
+    pub binary: Vec<String>,
+    pub version: String,
+    pub directory: String,
+    pub architecture: String,
+    pub uploaders: Vec<String>,
 }
 
 impl DebianSourcePkg {

--- a/worker/src/rebuild.rs
+++ b/worker/src/rebuild.rs
@@ -161,7 +161,7 @@ pub async fn rebuild(ctx: &Context<'_>) -> Result<Vec<(PkgArtifact, Rebuild)>> {
 
             // generate diffoscope diff if enabled
             if ctx.diffoscope.enabled {
-                let diff = diffoscope(&input_path, &output_path, &ctx.diffoscope)
+                let diff = diffoscope(&artifact_path, &output_path, &ctx.diffoscope)
                     .await
                     .context("Failed to run diffoscope")?;
                 res.diffoscope = Some(diff);


### PR DESCRIPTION
Currently diffoscope is run like this:
```
diffoscope /path/to.buildinfo /path/to/output.deb
```
this likely causing this exception:
```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/diffoscope/main.py", line 746, in main
    sys.exit(run_diffoscope(parsed_args))
  File "/usr/lib/python3/dist-packages/diffoscope/main.py", line 700, in run_diffoscope
    difference = compare_root_paths(path1, path2)
  File "/usr/lib/python3/dist-packages/diffoscope/comparators/utils/compare.py", line 69, in compare_root_paths
    difference = compare_files(file1, file2)
  File "/usr/lib/python3/dist-packages/diffoscope/comparators/utils/compare.py", line 125, in compare_files
    return file1.compare(file2, source)
  File "/usr/lib/python3/dist-packages/diffoscope/comparators/utils/file.py", line 494, in compare
    difference = self._compare_using_details(other, source)
  File "/usr/lib/python3/dist-packages/diffoscope/comparators/utils/file.py", line 401, in _compare_using_details
    details.extend(self.compare_details(other, source))
  File "/usr/lib/python3/dist-packages/diffoscope/comparators/debian.py", line 152, in compare_details
    gpg_b = self._parse_gpg(other)
  File "/usr/lib/python3/dist-packages/diffoscope/comparators/debian.py", line 143, in _parse_gpg
    header, _, footer = Deb822.split_gpg_and_payload(f)
  File "/usr/local/lib/python3.9/dist-packages/python_debian-0.1.40_git20211202-py3.9.egg/debian/deb822.py", line 1168, in split_gpg_and_payload
    for line_ in sequence:
  File "/usr/lib/python3.9/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xfd in position 132: invalid start byte
```
This doesn't affect Arch Linux because `input_url` and `artifact_url` have the same value there.