### PR TITLE
Match `application/x-bzip2`

### DIFF
--- a/tools/src/decompress.rs
+++ b/tools/src/decompress.rs
@@ -24,6 +24,7 @@ pub fn detect_compression(bytes: &[u8]) -> CompressedWith {
     match mime {
         "application/gzip" => CompressedWith::Gzip,
         "application/x-bzip" => CompressedWith::Bzip2,
+        "application/x-bzip2" => CompressedWith::Bzip2,
         "application/x-xz" => CompressedWith::Xz,
         "application/zstd" => CompressedWith::Zstd,
         _ => CompressedWith::Unknown,


### PR DESCRIPTION
`shared-mime-info` 2.3 yields `application/x-bzip2` instead of `application/x-bzip`

Add a new case to also match `application/x-bzip2`. Works with both versions of `shared-mime-info`

Fixes #138 