### PR TITLE
Preliminary NixOS rebuilding support

### DIFF
--- a/contrib/confs/rebuilderd-worker.conf
+++ b/contrib/confs/rebuilderd-worker.conf
@@ -31,3 +31,6 @@ path = "/usr/libexec/rebuilderd/rebuilder-debian.sh"
 
 [backend."tails"]
 path = "/usr/libexec/rebuilderd/rebuilder-tails.sh"
+
+[backend."nixos"]
+path = "/usr/libexec/rebuilderd/rebuilder-nixos.sh"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,18 @@ services:
     - REBUILDERD_COOKIE_PATH=/secret/auth
     volumes:
     - ./secret:/secret
+  worker-nixos:
+    build:
+      context: .
+      dockerfile: worker/Dockerfile.nixos
+    # number of concurrent workers
+    scale: 1
+    init: true
+    command: ['connect', 'http://daemon:8484']
+    environment:
+    - REBUILDERD_COOKIE_PATH=/secret/auth
+    volumes:
+    - ./secret:/secret
   worker-archlinux:
     build:
       context: .

--- a/worker/Dockerfile.nixos
+++ b/worker/Dockerfile.nixos
@@ -1,0 +1,26 @@
+FROM rust:bullseye
+WORKDIR /usr/src/rebuilderd
+RUN apt-get update && apt-get install -y libssl-dev
+COPY . .
+RUN --mount=type=cache,target=/var/cache/buildkit \
+    CARGO_HOME=/var/cache/buildkit/cargo \
+    CARGO_TARGET_DIR=/var/cache/buildkit/debian/target \
+    cargo build --release --locked -p rebuilderd-worker && \
+    cp -v /var/cache/buildkit/debian/target/release/rebuilderd-worker /
+
+FROM debian:bullseye
+RUN apt-get update && apt install -y libssl-dev git mmdebstrap diffoscope \
+    python3-apt python3-dateutil python3-requests python3-rstr python3-setuptools python3-httpx python3-tenacity \
+    debian-keyring debian-archive-keyring debian-ports-archive-keyring
+# this is a temporary solution
+# copied from https://github.com/fepitre/package-rebuilder/blob/fc38df2f6e81ae6307e47cf515caa3e92ec8f5a4/rebuilder.Dockerfile
+RUN git clone https://salsa.debian.org/python-debian-team/python-debian /opt/python-debian
+RUN cd /opt/python-debian && git checkout e28d7a5729b187cfd0ec95da25030224cd10021a && python3 setup.py build install
+RUN git clone --depth=1 'https://github.com/fepitre/debrebuild' /debrebuild
+RUN curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux --init none --no-confirm
+COPY --from=0 \
+    /usr/src/rebuilderd/worker/rebuilder-nixos.sh \
+    /usr/local/libexec/rebuilderd/
+COPY --from=0 /rebuilderd-worker /usr/local/bin/
+ENV REBUILDERD_WORKER_BACKEND=nixos=/usr/local/libexec/rebuilderd/rebuilder-nixos.sh
+ENTRYPOINT ["rebuilderd-worker"]

--- a/worker/rebuilder-nixos.sh
+++ b/worker/rebuilder-nixos.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -x
+
+echo "Rebuilding $1"
+export PATH=/root/.nix-profile/bin:$PATH
+whoami
+
+DRV=$(cat $1 | grep StorePath | cut -d ":" -f 2)
+
+REALIZED=$(nix-build --check $DRV)
+
+nix-store --dump $REALIZED > $REBUILDERD_OUTDIR/out.nar
+xz $REBUILDERD_OUTDIR/out.nar
+HASH=$(nix-hash --base32 --type sha256 --flat $REBUILDERD_OUTDIR/out.nar.xz)
+mv $REBUILDERD_OUTDIR/out.nar.xz $REBUILDERD_OUTDIR/$HASH.nar.xz


### PR DESCRIPTION
Taking pkgs specs of the form:

```
[
  {
    "name": "zlib",
    "version": "1.3@q9jf8xl1gsfmx4f1jhqpdc11yf0w9gv4",
    "distro": "nixos",
    "suite": "core",
    "architecture": "x86_64",
    "input_url": "https://cache.nixos.org/q9jf8xl1gsfmx4f1jhqpdc11yf0w9gv4.narinfo",
    "artifacts": [
      {
        "name": "zlib",
        "version": "1.3",
        "url": "https://cache.nixos.org/nar/1dv9dwz64z347s8b5s78lqrbgdl4xcm0l98zd9cm7jnz1ljd1gjy.nar.xz"
      }
    ]
  }
]
```

Yay:

```
Comparing "/tmp/rebuilderd03zPu6/inputs/1dv9dwz64z347s8b5s78lqrbgdl4xcm0l98zd9cm7jnz1ljd1gjy.nar.xz" with "/tmp/rebuilderd03zPu6/out/1dv9dwz64z347s8b5s78lqrbgdl4xcm0l98zd9cm7jnz1ljd1gjy.nar.xz"
```