### PR TITLE
Refactor xz/lzma decompression code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "zstd 0.13.2",
+ "zstd",
 ]
 
 [[package]]
@@ -1622,7 +1622,6 @@ dependencies = [
  "rebuilderd-common",
  "regex",
  "reqwest",
- "rust-lzma",
  "serde",
  "serde_json",
  "structopt",
@@ -1631,8 +1630,8 @@ dependencies = [
  "toml 0.5.11",
  "tree_magic_mini",
  "url",
- "xz",
- "zstd 0.11.2+zstd.1.5.2",
+ "xz2",
+ "zstd",
 ]
 
 [[package]]
@@ -1817,15 +1816,6 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
-]
-
-[[package]]
-name = "rust-lzma"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "895dc04daeaeee338bb96e229797902ed3f0675bfc59d5b42e0f0b0c13ac54da"
-dependencies = [
- "pkg-config",
 ]
 
 [[package]]
@@ -2804,15 +2794,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "xz"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c887690ff2a2e233e8e49633461521f98ec57fbff9d59a884c9a4f04ec1da34"
-dependencies = [
- "xz2",
-]
-
-[[package]]
 name = "xz2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2844,30 +2825,11 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe 5.0.2+zstd.1.5.2",
-]
-
-[[package]]
-name = "zstd"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
- "zstd-safe 7.2.1",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
+ "zstd-safe",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +509,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
 name = "colored"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,29 +703,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.9.3"
+name = "env_filter"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
 dependencies = [
- "atty",
- "humantime",
  "log",
  "regex",
- "termcolor",
 ]
 
 [[package]]
 name = "env_logger"
-version = "0.10.2"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
 dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
  "humantime",
- "is-terminal",
  "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -938,12 +990,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
-
-[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,15 +1169,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.13"
+name = "is_terminal_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
-dependencies = [
- "hermit-abi 0.4.0",
- "libc",
- "windows-sys 0.52.0",
-]
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -1615,7 +1656,7 @@ dependencies = [
  "colored",
  "data-encoding",
  "dirs-next",
- "env_logger 0.9.3",
+ "env_logger",
  "flate2",
  "glob",
  "nom",
@@ -1644,7 +1685,7 @@ dependencies = [
  "diesel_migrations",
  "dirs-next",
  "dotenv",
- "env_logger 0.10.2",
+ "env_logger",
  "log",
  "rand",
  "rebuilderd-common",
@@ -1675,7 +1716,7 @@ version = "0.20.0"
 dependencies = [
  "actix-web",
  "colored",
- "env_logger 0.9.3",
+ "env_logger",
  "futures 0.3.30",
  "rebuilderd",
  "rebuilderd-common",
@@ -1690,7 +1731,7 @@ version = "0.20.0"
 dependencies = [
  "async-trait",
  "data-encoding",
- "env_logger 0.10.2",
+ "env_logger",
  "futures 0.3.30",
  "futures-util",
  "in-toto",
@@ -2162,15 +2203,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2441,6 +2473,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,7 +1668,7 @@ dependencies = [
  "structopt",
  "tar",
  "tokio",
- "toml 0.5.11",
+ "toml",
  "tree_magic_mini",
  "url",
  "xz2",
@@ -1692,7 +1692,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
- "toml 0.8.19",
+ "toml",
 ]
 
 [[package]]
@@ -1706,7 +1706,7 @@ dependencies = [
  "log",
  "reqwest",
  "serde",
- "toml 0.8.19",
+ "toml",
  "url",
 ]
 
@@ -1743,7 +1743,7 @@ dependencies = [
  "structopt",
  "tempfile",
  "tokio",
- "toml 0.8.19",
+ "toml",
  "url",
 ]
 
@@ -2327,15 +2327,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -25,7 +25,7 @@ diesel = { version = "1.4.8", features = ["sqlite", "r2d2", "chrono"] }
 diesel_migrations = { version = "1.4.0", features = ["sqlite"] }
 dirs-next = "2.0.0"
 dotenv = "0.15.0"
-env_logger = "0.10"
+env_logger = "0.11"
 log = "0.4.17"
 rand = "0.8.5"
 rebuilderd-common = { version= "=0.20.0", path="../common" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 actix-web = "4.1.0"
 colored = "2.0.0"
-env_logger = "0.9.0"
+env_logger = "0.11"
 futures = "0.3.21"
 rebuilderd = { version= "=0.20.0", path="../daemon" }
 rebuilderd-common = { version= "=0.20.0", path="../common" }

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -21,7 +21,6 @@ structopt = "0.3.26"
 env_logger = "0.9.0"
 reqwest = { version="0.11.11", features=["json"] }
 chrono = { version = "0.4.19", features=["serde"] }
-rust-lzma = "0.5.1"
 tar = "0.4.38"
 flate2 = "1.0.24"
 serde = { version="1.0.137", features=["derive"] }
@@ -35,8 +34,8 @@ tokio = { version="1.19.2", features=["macros", "rt-multi-thread", "io-std", "io
 atty = "0.2.14"
 tree_magic_mini = "3.0.3"
 bzip2 = "0.4.3"
-xz = "0.1.0"
-zstd = { version = "0.11.2", features = ["pkg-config"] }
+xz2 = "0.1"
+zstd = { version = "0.13", features = ["pkg-config"] }
 regex = "1.5.6"
 url = "2.2.2"
 

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -18,7 +18,7 @@ assets = [
 [dependencies]
 rebuilderd-common = { version= "=0.20.0", path="../common" }
 structopt = "0.3.26"
-env_logger = "0.9.0"
+env_logger = "0.11"
 reqwest = { version="0.11.11", features=["json"] }
 chrono = { version = "0.4.19", features=["serde"] }
 tar = "0.4.38"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -26,7 +26,7 @@ flate2 = "1.0.24"
 serde = { version="1.0.137", features=["derive"] }
 serde_json = "1.0.81"
 colored = "2.0.0"
-toml = "0.5.9"
+toml = "0.8"
 dirs-next = "2.0.0"
 glob = "0.3.0"
 nom = "7.1.1"

--- a/tools/src/config.rs
+++ b/tools/src/config.rs
@@ -12,9 +12,9 @@ pub struct SyncConfigFile {
 
 impl SyncConfigFile {
     pub fn load<P: AsRef<Path>>(path: P) -> Result<SyncConfigFile> {
-        let buf = fs::read(path)
+        let buf = fs::read_to_string(path)
             .context("Failed to read config file")?;
-        let config = toml::from_slice(&buf)
+        let config = toml::from_str(&buf)
             .context("Failed to load config")?;
         Ok(config)
     }

--- a/tools/src/decompress.rs
+++ b/tools/src/decompress.rs
@@ -2,7 +2,7 @@ use rebuilderd_common::errors::*;
 use std::io::Read;
 use flate2::read::GzDecoder;
 use bzip2::read::BzDecoder;
-use xz::read::XzDecoder;
+use xz2::read::XzDecoder;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum CompressedWith {

--- a/tools/src/schedule/debian.rs
+++ b/tools/src/schedule/debian.rs
@@ -1,6 +1,6 @@
 use crate::args::PkgsSync;
 use crate::schedule::{Pkg, fetch_url_or_path};
-use lzma::LzmaReader;
+use xz2::read::XzDecoder;
 use rebuilderd_common::{PkgGroup, PkgArtifact};
 use rebuilderd_common::errors::*;
 use std::collections::HashMap;
@@ -194,7 +194,7 @@ impl AnyhowTryFrom<NewPkg> for DebianBinPkg {
 }
 
 pub fn extract_pkg<T: AnyhowTryFrom<NewPkg>>(bytes: &[u8]) -> Result<Vec<T>> {
-    let r = LzmaReader::new_decompressor(bytes)?;
+    let r = XzDecoder::new(bytes);
     let r = BufReader::new(r);
     extract_pkgs_uncompressed(r)
 }

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -20,7 +20,7 @@ assets = [
 [dependencies]
 rebuilderd-common = { version= "=0.20.0", path="../common" }
 structopt = "0.3.26"
-env_logger = "0.10.0"
+env_logger = "0.11"
 data-encoding = "2"
 toml = "0.8"
 serde = { version="1.0.137", features=["derive"] }


### PR DESCRIPTION
`xz` and `rust-lzma` are conflicting at their latest versions, but `xz2` seems like the better choice anyway.