### PR TITLE
contrib: update Fedora example configuration

### DIFF
--- a/contrib/confs/rebuilderd-sync.conf
+++ b/contrib/confs/rebuilderd-sync.conf
@@ -21,7 +21,8 @@ source = "https://ftp.halifax.rwth-aachen.de/archlinux/$repo/os/$arch"
 distro = "fedora"
 suite = "Everything"
 architectures = ["x86_64"]
-source = "https://ftp.halifax.rwth-aachen.de/fedora/linux/releases"
+releases = ["rawhide"]
+source = "https://ftp.halifax.rwth-aachen.de/fedora/linux/development"
 
 [profile."debian-main"]
 distro = "debian"


### PR DESCRIPTION
Fedora has releases which was missing and switch it to rawhide which should work always work instead of older releases which might get outdated.