### PR TITLE
Implement support for storing compressed build logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,6 +1901,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,6 +1922,8 @@ dependencies = [
  "rebuilderd-common",
  "serde",
  "serde_json",
+ "tokio",
+ "tokio-test",
  "toml",
  "zstd",
 ]
@@ -2560,6 +2584,30 @@ checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -32,9 +32,9 @@ rand = "0.9"
 rebuilderd-common = { version = "=0.23.0", path = "../common" }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
+tokio = "1.44.2"
 toml = "0.8"
 zstd = "0.13.3"
-tokio = "1.44.2"
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -20,7 +20,7 @@ assets = [
 
 [dependencies]
 actix-web = "4.1.0"
-chrono = { version = "0.4.19", features=["serde"] }
+chrono = { version = "0.4.19", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 diesel = { version = "2", features = ["sqlite", "r2d2", "chrono", "i-implement-a-third-party-backend-and-opt-into-breaking-changes"] }
 diesel_migrations = { version = "2", features = ["sqlite"] }
@@ -29,10 +29,14 @@ dotenvy = "0.15.0"
 env_logger = "0.11"
 log = "0.4.17"
 rand = "0.9"
-rebuilderd-common = { version= "=0.23.0", path="../common" }
-serde = { version="1.0.137", features=["derive"] }
+rebuilderd-common = { version = "=0.23.0", path = "../common" }
+serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 toml = "0.8"
 zstd = "0.13.3"
+tokio = "1.44.2"
+
+[dev-dependencies]
+tokio-test = "0.4.4"
 
 # https://crates.io/crates/deb-version

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -33,5 +33,6 @@ rebuilderd-common = { version= "=0.23.0", path="../common" }
 serde = { version="1.0.137", features=["derive"] }
 serde_json = "1.0.81"
 toml = "0.8"
+zstd = "0.13.3"
 
 # https://crates.io/crates/deb-version

--- a/daemon/migrations/2025-05-20-210543_compress-logs/down.sql
+++ b/daemon/migrations/2025-05-20-210543_compress-logs/down.sql
@@ -1,4 +1,4 @@
-PRAGMA foreign_keys= off;
+PRAGMA foreign_keys=off;
 
 CREATE TABLE _builds_new
 (
@@ -17,4 +17,4 @@ DROP TABLE builds;
 ALTER TABLE _builds_new
     RENAME TO builds;
 
-PRAGMA foreign_keys= on;
+PRAGMA foreign_keys=on;

--- a/daemon/migrations/2025-05-20-210543_compress-logs/down.sql
+++ b/daemon/migrations/2025-05-20-210543_compress-logs/down.sql
@@ -1,0 +1,1 @@
+-- code-only migration

--- a/daemon/migrations/2025-05-20-210543_compress-logs/down.sql
+++ b/daemon/migrations/2025-05-20-210543_compress-logs/down.sql
@@ -1,1 +1,20 @@
--- code-only migration
+PRAGMA foreign_keys= off;
+
+CREATE TABLE _builds_new
+(
+    id          INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    diffoscope  TEXT,
+    build_log   BLOB    NOT NULL,
+    attestation VARCHAR
+);
+
+INSERT INTO _builds_new(id, diffoscope, build_log, attestation)
+SELECT id, diffoscope, build_log, attestation
+FROM builds;
+
+DROP TABLE builds;
+
+ALTER TABLE _builds_new
+    RENAME TO builds;
+
+PRAGMA foreign_keys= on;

--- a/daemon/migrations/2025-05-20-210543_compress-logs/up.sql
+++ b/daemon/migrations/2025-05-20-210543_compress-logs/up.sql
@@ -1,1 +1,20 @@
--- code-only migration
+PRAGMA foreign_keys= off;
+
+CREATE TABLE _builds_new
+(
+    id          INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    diffoscope  BLOB,
+    build_log   BLOB    NOT NULL,
+    attestation BLOB
+);
+
+INSERT INTO _builds_new(id, diffoscope, build_log, attestation)
+SELECT id, diffoscope, build_log, attestation
+FROM builds;
+
+DROP TABLE builds;
+
+ALTER TABLE _builds_new
+    RENAME TO builds;
+
+PRAGMA foreign_keys= on;

--- a/daemon/migrations/2025-05-20-210543_compress-logs/up.sql
+++ b/daemon/migrations/2025-05-20-210543_compress-logs/up.sql
@@ -1,4 +1,4 @@
-PRAGMA foreign_keys= off;
+PRAGMA foreign_keys=off;
 
 CREATE TABLE _builds_new
 (
@@ -17,4 +17,4 @@ DROP TABLE builds;
 ALTER TABLE _builds_new
     RENAME TO builds;
 
-PRAGMA foreign_keys= on;
+PRAGMA foreign_keys=on;

--- a/daemon/migrations/2025-05-20-210543_compress-logs/up.sql
+++ b/daemon/migrations/2025-05-20-210543_compress-logs/up.sql
@@ -1,0 +1,1 @@
+-- code-only migration

--- a/daemon/src/code_migrations/code_migration.rs
+++ b/daemon/src/code_migrations/code_migration.rs
@@ -1,3 +1,4 @@
+use crate::code_migrations::compress_logs::CompressLogsMigration;
 use diesel::migration::Result;
 use diesel::migration::{Migration, MigrationVersion};
 use diesel::sqlite::Sqlite;
@@ -51,7 +52,8 @@ impl CodeMigration for UnitCodeMigration {}
 
 fn get_code_migration(migration: &dyn Migration<Sqlite>) -> Box<dyn CodeMigration> {
     match migration.name().to_string().as_str() {
-        _ => Box::new(UnitCodeMigration)
+        "2025-05-20-210543_compress-logs" => Box::new(CompressLogsMigration),
+        _ => Box::new(UnitCodeMigration),
     }
 }
 

--- a/daemon/src/code_migrations/code_migration.rs
+++ b/daemon/src/code_migrations/code_migration.rs
@@ -1,0 +1,81 @@
+use diesel::migration::Result;
+use diesel::migration::{Migration, MigrationVersion};
+use diesel::sqlite::Sqlite;
+use diesel::{Connection, SqliteConnection};
+use diesel_migrations::MigrationHarness;
+
+pub trait CodeMigration {
+    fn prepare(
+        &self,
+        _connection: &mut SqliteConnection,
+        _migration: &dyn Migration<Sqlite>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn pre_up(
+        &self,
+        _connection: &mut SqliteConnection,
+        _migration: &dyn Migration<Sqlite>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn pre_down(
+        &self,
+        _connection: &mut SqliteConnection,
+        _migration: &dyn Migration<Sqlite>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn post_up(
+        &self,
+        _connection: &mut SqliteConnection,
+        _migration: &dyn Migration<Sqlite>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn post_down(
+        &self,
+        _connection: &mut SqliteConnection,
+        _migration: &dyn Migration<Sqlite>,
+    ) -> Result<()> {
+        Ok(())
+    }
+}
+
+struct UnitCodeMigration;
+impl CodeMigration for UnitCodeMigration {}
+
+fn get_code_migration(migration: &dyn Migration<Sqlite>) -> Box<dyn CodeMigration> {
+    match migration.name().to_string().as_str() {
+        _ => Box::new(UnitCodeMigration)
+    }
+}
+
+pub fn run_code_backed_migration(
+    connection: &mut SqliteConnection,
+    migration: &dyn Migration<Sqlite>,
+) -> Result<MigrationVersion<'static>> {
+    let code_migration = get_code_migration(migration);
+
+    code_migration.prepare(connection, migration)?;
+
+    if migration.metadata().run_in_transaction() {
+        connection.transaction(|c| code_migration.pre_up(c, migration))?;
+    } else {
+        code_migration.pre_up(connection, migration)?;
+    }
+
+    let version = connection.run_migration(migration)?;
+
+    if migration.metadata().run_in_transaction() {
+        connection.transaction(|c| code_migration.post_up(c, migration))?;
+    } else {
+        code_migration.post_up(connection, migration)?;
+    }
+
+    Ok(version)
+}

--- a/daemon/src/code_migrations/compress_logs.rs
+++ b/daemon/src/code_migrations/compress_logs.rs
@@ -1,0 +1,56 @@
+use crate::code_migrations::code_migration::CodeMigration;
+use diesel::migration::Migration;
+use diesel::sql_types::Binary;
+use diesel::sqlite::Sqlite;
+use diesel::{define_sql_function, sql_query, RunQueryDsl, SqliteConnection};
+use log::info;
+
+pub struct CompressLogsMigration;
+
+define_sql_function! {
+    fn zstd_compress(data: Binary) -> Binary;
+}
+
+define_sql_function! {
+    fn zstd_decompress(data: Binary) -> Binary;
+}
+
+impl CodeMigration for CompressLogsMigration {
+    fn prepare(
+        &self,
+        connection: &mut SqliteConnection,
+        _: &dyn Migration<Sqlite>,
+    ) -> diesel::migration::Result<()> {
+        zstd_compress_utils::register_impl(connection, |data: Vec<u8>| {
+            zstd::encode_all(&data[..], 11).unwrap()
+        })?;
+        zstd_decompress_utils::register_impl(connection, |data: Vec<u8>| {
+            zstd::decode_all(&data[..]).unwrap()
+        })?;
+
+        Ok(())
+    }
+
+    fn post_up(
+        &self,
+        connection: &mut SqliteConnection,
+        _: &dyn Migration<Sqlite>,
+    ) -> diesel::migration::Result<()> {
+        info!("compressing build logs (this might take a while)");
+        sql_query("UPDATE builds SET build_log = zstd_compress(build_log);").execute(connection)?;
+
+        Ok(())
+    }
+
+    fn post_down(
+        &self,
+        connection: &mut SqliteConnection,
+        _: &dyn Migration<Sqlite>,
+    ) -> diesel::migration::Result<()> {
+        info!("decompressing build logs (this might take a while)");
+        sql_query("UPDATE builds SET build_log = zstd_decompress(build_log);")
+            .execute(connection)?;
+
+        Ok(())
+    }
+}

--- a/daemon/src/code_migrations/mod.rs
+++ b/daemon/src/code_migrations/mod.rs
@@ -1,0 +1,1 @@
+pub mod code_migration;

--- a/daemon/src/code_migrations/mod.rs
+++ b/daemon/src/code_migrations/mod.rs
@@ -1,1 +1,2 @@
 pub mod code_migration;
+mod compress_logs;

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -28,6 +28,7 @@ pub fn setup(url: &str) -> Result<SqliteConnection> {
         info!("Applied database migration: {version}");
     }
 
+    info!("reclaiming disk space (this might take a while)");
     sql_query("VACUUM;").execute(&mut connection)?;
 
     Ok(connection)

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -16,10 +16,8 @@ pub fn setup(url: &str) -> Result<SqliteConnection> {
     let mut connection = SqliteConnection::establish(url)?;
 
     let mut database_schema_changed = false;
-    while connection
-        .has_pending_migration(MIGRATIONS)
-        .map_err(|err| anyhow!("Failed to check for pending migrations: {err:#}"))?
-    {
+
+    loop {
         let pending_migrations = connection
             .pending_migrations(MIGRATIONS)
             .map_err(|err| anyhow!("Failed to check for pending migrations: {err:#}"))?;

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -19,8 +19,13 @@ pub fn setup(url: &str) -> Result<SqliteConnection> {
         .has_pending_migration(MIGRATIONS)
         .map_err(|err| anyhow!("Failed to check for pending migrations: {err:#}"))?
     {
-        let pending_migrations = connection.pending_migrations(MIGRATIONS).unwrap();
-        let next_migration = pending_migrations.first().unwrap();
+        let pending_migrations = connection
+            .pending_migrations(MIGRATIONS)
+            .map_err(|err| anyhow!("Failed to check for pending migrations: {err:#}"))?;
+
+        let Some(next_migration) = pending_migrations.first() else {
+            break;
+        };
 
         let version = code_migration::run_code_backed_migration(&mut connection, next_migration)
             .map_err(|err| anyhow!("Failed to run pending migration: {err:#}"))?;

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 
 pub mod api;
 pub mod auth;
+pub mod code_migrations;
 pub mod config;
 pub mod dashboard;
 pub mod db;

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -22,6 +22,7 @@ pub mod db;
 pub mod models;
 pub mod schema;
 pub mod sync;
+pub mod util;
 pub mod web;
 
 fn db_collect_garbage(connection: &mut SqliteConnection) -> Result<()> {

--- a/daemon/src/schema.rs
+++ b/daemon/src/schema.rs
@@ -3,9 +3,9 @@
 diesel::table! {
     builds (id) {
         id -> Integer,
-        diffoscope -> Nullable<Text>,
+        diffoscope -> Nullable<Binary>,
         build_log -> Binary,
-        attestation -> Nullable<Text>,
+        attestation -> Nullable<Binary>,
     }
 }
 

--- a/daemon/src/util.rs
+++ b/daemon/src/util.rs
@@ -1,0 +1,77 @@
+use std::io::{Read, Write};
+use std::{cmp, io};
+use zstd::{Decoder, Encoder};
+
+pub const ZSTD_MAGIC: [u8; 4] = [0x28, 0xb5, 0x2f, 0xfd];
+
+// zstd has an internal buffer of 128kb - attempting to fill it completely with each chunk should
+// get us near-optimal throughput
+pub const ZSTD_CHUNK_SIZE: usize = 1024 * 128;
+
+/// Compresses a block of data using the zstd algorithm in asynchronous chunks, yielding in between each one.
+///
+/// Chunks are sized to fit within zstd's default internal buffer size.
+/// ```rust
+/// use std::io::{repeat, Read};
+/// use rebuilderd::util::{zstd_compress, zstd_decompress, ZSTD_CHUNK_SIZE};
+///
+/// tokio_test::block_on(async {
+/// let undersized_data = "a".repeat(ZSTD_CHUNK_SIZE - 1).into_bytes();
+/// let evenly_sized_data = "a".repeat(ZSTD_CHUNK_SIZE).into_bytes();
+/// let oversized_data = "a".repeat(ZSTD_CHUNK_SIZE + 1).into_bytes();
+///
+/// let compressed = zstd_compress(&undersized_data).await.unwrap();
+/// let decompressed = zstd_decompress(&compressed).await.unwrap();
+/// assert_eq!(decompressed, undersized_data, "undersized data did not survive round-trip");
+///
+/// let compressed = zstd_compress(&evenly_sized_data).await.unwrap();
+/// let decompressed = zstd_decompress(&compressed).await.unwrap();
+/// assert_eq!(decompressed, evenly_sized_data, "evenly sized data did not survive round-trip");
+///
+/// let compressed = zstd_compress(&oversized_data).await.unwrap();
+/// let decompressed = zstd_decompress(&compressed).await.unwrap();
+/// assert_eq!(decompressed, oversized_data, "oversized data did not survive round-trip");
+/// })
+/// ```
+pub async fn zstd_compress(data: &[u8]) -> io::Result<Vec<u8>> {
+    let mut encoder = Encoder::new(Vec::new(), 11)?;
+
+    let mut position = 0;
+    while position < data.len() {
+        tokio::task::yield_now().await;
+
+        let slice = &data[position..cmp::min(position + ZSTD_CHUNK_SIZE, data.len())];
+        encoder.write_all(slice)?;
+
+        position += slice.len();
+    }
+
+    encoder.finish()
+}
+
+/// Decompresses a block of data using the zstd algorithm in asynchronous chunks, yielding in between each one.
+///
+/// Chunks are sized to fit within zstd's default internal buffer size.
+pub async fn zstd_decompress(data: &[u8]) -> io::Result<Vec<u8>> {
+    let mut decoder = Decoder::new(data)?;
+    let mut data = vec![];
+
+    loop {
+        tokio::task::yield_now().await;
+
+        let mut buf = vec![0u8; ZSTD_CHUNK_SIZE];
+        let read_bytes = decoder.read(&mut buf)?;
+        if read_bytes == 0 {
+            break;
+        }
+
+        data.extend_from_slice(&buf[0..read_bytes]);
+    }
+
+    Ok(data)
+}
+
+/// Checks if a block of data is compressed with the zstd algorithm.
+pub fn is_zstd_compressed(data: &[u8]) -> bool {
+    data.starts_with(&ZSTD_MAGIC)
+}

--- a/daemon/src/util.rs
+++ b/daemon/src/util.rs
@@ -1,5 +1,5 @@
+use std::io;
 use std::io::{Read, Write};
-use std::{cmp, io};
 use zstd::{Decoder, Encoder};
 
 pub const ZSTD_MAGIC: [u8; 4] = [0x28, 0xb5, 0x2f, 0xfd];
@@ -36,14 +36,9 @@ pub const ZSTD_CHUNK_SIZE: usize = 1024 * 128;
 pub async fn zstd_compress(data: &[u8]) -> io::Result<Vec<u8>> {
     let mut encoder = Encoder::new(Vec::new(), 11)?;
 
-    let mut position = 0;
-    while position < data.len() {
+    for slice in data.chunks(ZSTD_CHUNK_SIZE) {
         tokio::task::yield_now().await;
-
-        let slice = &data[position..cmp::min(position + ZSTD_CHUNK_SIZE, data.len())];
         encoder.write_all(slice)?;
-
-        position += slice.len();
     }
 
     encoder.finish()

--- a/daemon/src/util.rs
+++ b/daemon/src/util.rs
@@ -56,10 +56,10 @@ pub async fn zstd_decompress(data: &[u8]) -> io::Result<Vec<u8>> {
     let mut decoder = Decoder::new(data)?;
     let mut data = vec![];
 
+    let mut buf = vec![0u8; ZSTD_CHUNK_SIZE];
     loop {
         tokio::task::yield_now().await;
 
-        let mut buf = vec![0u8; ZSTD_CHUNK_SIZE];
         let read_bytes = decoder.read(&mut buf)?;
         if read_bytes == 0 {
             break;


### PR DESCRIPTION
This PR augments log storage with compression to reduce the size of the on-disk database. The changes should be forward- and backwards-compatible, though no attempt is currently made to transition already-saved logs to compressed data.

Logs are now stored in the database as zstd-compressed blobs by default. Clients requesting build logs may be served the raw zstd-compressed data if they indicate support for it via the Accept-Encoding header; otherwise, the logs are decompressed and served as plaintext.

Additional compression may be applied by the Actix compression middleware on plaintext logs if the client supports compressions other than zstd.