### PR TITLE
Remove VACUUM from migration - rebuilderd automatically does this on schema changes

### DIFF
--- a/daemon/migrations/2025-06-01-095202_redesign_database/up.sql
+++ b/daemon/migrations/2025-06-01-095202_redesign_database/up.sql
@@ -159,8 +159,6 @@ SELECT attestation
 
 CREATE INDEX _temp_attestation_logs_attestation_log_idx ON attestation_logs (attestation_log);
 
-VACUUM;
-
 -- rebuilds
 CREATE TABLE rebuilds
 (


### PR DESCRIPTION
This defers the VACUUM until after the migration - when connecting to the database, after applying any pending database migrations, we have this code:

```rust
if database_schema_changed {
    info!("reclaiming disk space (this might take a while)");
    sql_query("VACUUM;").execute(&mut connection)?;

    info!("analyzing new schema and optimizing queries");
    sql_query("ANALYZE;").execute(&mut connection)?;
}
```

Related to #184.