### PR TITLE
Uncomment section headers in the default config file.

### DIFF
--- a/contrib/confs/rebuilderd.conf
+++ b/contrib/confs/rebuilderd.conf
@@ -1,5 +1,5 @@
 ## Configuration for http daemon
-#[http]
+[http]
 ## The address to bind to. This is 127.0.0.1:8484 by default.
 #bind_addr = "0.0.0.0:8484"
 ## If you use a reverse proxy, use this header instead of the actual connecting ip.
@@ -16,7 +16,7 @@
 ## You can set this to a fixed value here. Use `pwgen -1s 32` to generate one.
 ## rebuildctl is searching for this cookie in ~/.config/rebuilderd.conf, /etc/rebuilderd.conf and
 ## /var/lib/rebuilderd/auth-cookie in that order.
-#[auth]
+[auth]
 #cookie = "INSECURE"
 
 ## The auth cookie above is only used for the default endpoint.
@@ -26,14 +26,14 @@
 #cookie = "INSECURE"
 
 ## IMPORTANT: in production, make sure either `authorized_workers` or `signup_secret` is configured.
-#[worker]
+[worker]
 ## If we have a fixed set of workers we can allow-list the keys here.
 #authorized_workers = ["key1", "key2"]
 ## If we want to spawn new workers dynamically we can configure a sign up secret below.
 ## Use `pwgen -1s 32` to generate one.
 #signup_secret = "INSECURE"
 
-#[schedule]
+[schedule]
 ## Configure the delay to automatically retry failed rebuilds in hours. The
 ## default is 24h, this base is multiplied with the number of rebuilds, so the
 ## first retry would happen after 24h, the second retry would happen 48h after the


### PR DESCRIPTION
This reduces the risk of config options not being effective due to people forgetting to uncomment the section headers too.