### PR TITLE
Add a search_type filter for exact, contains and startsWith search modes

### DIFF
--- a/common/src/api/v1/models/mod.rs
+++ b/common/src/api/v1/models/mod.rs
@@ -42,17 +42,35 @@ pub struct OriginFilter {
     pub architecture: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct SourceIdentityFilter {
     pub name: Option<String>,
+    #[serde(default)]
+    pub search_type: SearchType,
     pub version: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct BinaryIdentityFilter {
     pub name: Option<String>,
+    #[serde(default)]
+    pub search_type: SearchType,
     pub version: Option<String>,
     pub source_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SearchType {
+    Exact,
+    Contains,
+    StartsWith,
+}
+
+impl Default for SearchType {
+    fn default() -> Self {
+        Self::Exact
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/contrib/docs/rebuilderd-v1.yml
+++ b/contrib/docs/rebuilderd-v1.yml
@@ -39,6 +39,7 @@ paths:
         - $ref: '#/components/parameters/component'
 
         - $ref: '#/components/parameters/name'
+        - $ref: '#/components/parameters/search_type'
         - $ref: '#/components/parameters/version'
         - $ref: '#/components/parameters/architecture'
       responses:
@@ -271,6 +272,7 @@ paths:
         - $ref: '#/components/parameters/component'
 
         - $ref: '#/components/parameters/name'
+        - $ref: '#/components/parameters/search_type'
         - $ref: '#/components/parameters/version'
       responses:
         "200":
@@ -330,6 +332,7 @@ paths:
 
         - $ref: '#/components/parameters/name'
         - $ref: '#/components/parameters/source_name'
+        - $ref: '#/components/parameters/search_type'
         - $ref: '#/components/parameters/version'
         - $ref: '#/components/parameters/architecture'
       responses:
@@ -389,6 +392,7 @@ paths:
         - $ref: '#/components/parameters/component'
 
         - $ref: '#/components/parameters/name'
+        - $ref: '#/components/parameters/search_type'
         - $ref: '#/components/parameters/version'
         - $ref: '#/components/parameters/architecture'
       responses:
@@ -438,6 +442,7 @@ paths:
         - $ref: '#/components/parameters/component'
 
         - $ref: '#/components/parameters/name'
+        - $ref: '#/components/parameters/search_type'
         - $ref: '#/components/parameters/version'
         - $ref: '#/components/parameters/architecture'
       responses:
@@ -1486,6 +1491,22 @@ components:
         type: string
       description: |-
         Filters the results by the version of the package.
+    search_type:
+      in: query
+      name: search_type
+      required: false
+      schema:
+        type: string
+        enum:
+          - exact
+          - contains
+          - starts_with
+        default: exact
+      description: |-
+        Specifies the matching strategy for the 'name' parameter.
+        - `exact`: Matches the name exactly (default).
+        - `contains`: Matches if the name contains the provided string.
+        - `starts_with`: Matches if the name starts with the provided string.
     distribution:
       in: query
       name: distribution

--- a/daemon/src/api/v1/queue.rs
+++ b/daemon/src/api/v1/queue.rs
@@ -118,6 +118,7 @@ pub async fn request_rebuild(
     let source_identity_filter = SourceIdentityFilter {
         name: queue_request.name,
         version: queue_request.version,
+        ..Default::default()
     };
 
     let mut sql = source_packages::table

--- a/daemon/src/api/v1/util/filters.rs
+++ b/daemon/src/api/v1/util/filters.rs
@@ -7,9 +7,7 @@ use diesel::sql_types::{Bool, Text};
 use diesel::sqlite::Sqlite;
 use diesel::{BoolExpressionMethods, BoxableExpression, Expression, SelectableExpression};
 use diesel::{ExpressionMethods, SqliteExpressionMethods};
-use rebuilderd_common::api::v1::{
-    BinaryIdentityFilter, FreshnessFilter, OriginFilter, SourceIdentityFilter,
-};
+use rebuilderd_common::api::v1::{BinaryIdentityFilter, FreshnessFilter, OriginFilter, SearchType, SourceIdentityFilter};
 
 pub trait IntoSourceIdentityFilter<QS, DB>
 where
@@ -66,9 +64,14 @@ impl<T: 'static> IntoSourceIdentityFilter<T, Sqlite> for SourceIdentityFilter {
             + Send
             + 'static,
     {
-        let name_is: Self::Output = match self.name {
-            Some(name) => Box::new(name_column.is(name)),
-            None => Box::new(AsExpression::<Bool>::as_expression(true)),
+        let name_is: Self::Output = if let Some(name) = self.name {
+            match self.search_type {
+                SearchType::Exact => Box::new(name_column.eq(name)),
+                SearchType::Contains => Box::new(name_column.like(format!("%{name}%"))),
+                SearchType::StartsWith => Box::new(name_column.like(format!("{name}%"))),
+            }
+        } else {
+            Box::new(AsExpression::<Bool>::as_expression(true))
         };
 
         let version_is: Self::Output = match self.version {
@@ -151,9 +154,14 @@ impl<T: 'static> IntoBinaryIdentityFilter<T, Sqlite> for BinaryIdentityFilter {
             + Send
             + 'static,
     {
-        let name_is: Self::Output = match self.name {
-            Some(name) => Box::new(name_column.is(name)),
-            None => Box::new(AsExpression::<Bool>::as_expression(true)),
+        let name_is: Self::Output = if let Some(name) = self.name {
+            match self.search_type {
+                SearchType::Exact => Box::new(name_column.eq(name)),
+                SearchType::Contains => Box::new(name_column.like(format!("%{name}%"))),
+                SearchType::StartsWith => Box::new(name_column.like(format!("{name}%"))),
+            }
+        } else {
+            Box::new(AsExpression::<Bool>::as_expression(true))
         };
 
         let version_is: Self::Output = match self.version {

--- a/daemon/src/api/v1/util/filters.rs
+++ b/daemon/src/api/v1/util/filters.rs
@@ -6,10 +6,12 @@ use diesel::query_builder::QueryFragment;
 use diesel::sql_types::{Bool, Text};
 use diesel::sqlite::Sqlite;
 use diesel::{
-    BoolExpressionMethods, BoxableExpression, Expression, ExpressionMethods,
-    SelectableExpression, SqliteExpressionMethods, TextExpressionMethods,
+    BoolExpressionMethods, BoxableExpression, Expression, ExpressionMethods, SelectableExpression,
+    SqliteExpressionMethods, TextExpressionMethods,
 };
-use rebuilderd_common::api::v1::{BinaryIdentityFilter, FreshnessFilter, OriginFilter, SearchType, SourceIdentityFilter};
+use rebuilderd_common::api::v1::{
+    BinaryIdentityFilter, FreshnessFilter, OriginFilter, SearchType, SourceIdentityFilter,
+};
 
 pub trait IntoSourceIdentityFilter<QS, DB>
 where

--- a/daemon/src/api/v1/util/filters.rs
+++ b/daemon/src/api/v1/util/filters.rs
@@ -5,8 +5,10 @@ use diesel::expression::{AsExpression, ValidGrouping};
 use diesel::query_builder::QueryFragment;
 use diesel::sql_types::{Bool, Text};
 use diesel::sqlite::Sqlite;
-use diesel::{BoolExpressionMethods, BoxableExpression, Expression, SelectableExpression};
-use diesel::{ExpressionMethods, SqliteExpressionMethods};
+use diesel::{
+    BoolExpressionMethods, BoxableExpression, Expression, ExpressionMethods,
+    SelectableExpression, SqliteExpressionMethods, TextExpressionMethods,
+};
 use rebuilderd_common::api::v1::{BinaryIdentityFilter, FreshnessFilter, OriginFilter, SearchType, SourceIdentityFilter};
 
 pub trait IntoSourceIdentityFilter<QS, DB>

--- a/tests/src/api/v1/build/get_builds.rs
+++ b/tests/src/api/v1/build/get_builds.rs
@@ -4,7 +4,8 @@ use crate::fixtures::server::IsolatedServer;
 use crate::fixtures::*;
 use crate::setup;
 use rebuilderd_common::api::v1::{
-    BuildRestApi, OriginFilter, PackageReport, PackageRestApi, Page, SourceIdentityFilter,
+    BuildRestApi, OriginFilter, PackageReport, PackageRestApi, Page, SearchType,
+    SourceIdentityFilter,
 };
 use rstest::rstest;
 
@@ -234,26 +235,31 @@ pub async fn returns_result_for_matching_origin_filter(
 #[rstest]
 #[case(SourceIdentityFilter{
         name: Some(DUMMY_SOURCE_PACKAGE.to_string()),
+        search_type: SearchType::Exact,
         version: None,
     },
     1)]
 #[case(SourceIdentityFilter{
         name: Some(DUMMY_MULTI_ARTIFACT_SOURCE_PACKAGE.to_string()),
+        search_type: SearchType::Exact,
         version: None,
     },
     1)]
 #[case(SourceIdentityFilter{
         name: None,
+        search_type: SearchType::Exact,
         version: Some(DUMMY_SOURCE_PACKAGE_VERSION.to_string()),
     },
     1)]
 #[case(SourceIdentityFilter{
         name: None,
+        search_type: SearchType::Exact,
         version: Some(DUMMY_MULTI_ARTIFACT_SOURCE_PACKAGE_VERSION.to_string()),
     },
     1)]
 #[case(SourceIdentityFilter{
         name: None,
+        search_type: SearchType::Exact,
         version: None,
     },
     2)]

--- a/tests/src/api/v1/package/get_binary_packages.rs
+++ b/tests/src/api/v1/package/get_binary_packages.rs
@@ -3,7 +3,7 @@ use crate::fixtures::server::IsolatedServer;
 use crate::fixtures::*;
 use crate::setup;
 use rebuilderd_common::api::v1::{
-    BinaryIdentityFilter, OriginFilter, PackageReport, PackageRestApi, Page,
+    BinaryIdentityFilter, OriginFilter, PackageReport, PackageRestApi, Page, SearchType,
 };
 use rstest::rstest;
 
@@ -211,30 +211,35 @@ pub async fn returns_result_for_matching_origin_filter(
 #[rstest]
 #[case(BinaryIdentityFilter{
         name: Some(DUMMY_MULTI_ARTIFACT_BINARY_PACKAGE_1.to_string()),
+        search_type: SearchType::Exact,
         version: None,
         source_name: None,
     },
     1)]
 #[case(BinaryIdentityFilter{
         name: Some(DUMMY_MULTI_ARTIFACT_BINARY_PACKAGE_2.to_string()),
+        search_type: SearchType::Exact,
         version: None,
         source_name: None,
     },
     1)]
 #[case(BinaryIdentityFilter{
         name: None,
+        search_type: SearchType::Exact,
         version: Some(DUMMY_MULTI_ARTIFACT_BINARY_PACKAGE_1_VERSION.to_string()),
         source_name: None,
     },
     1)]
 #[case(BinaryIdentityFilter{
         name: None,
+        search_type: SearchType::Exact,
         version: Some(DUMMY_MULTI_ARTIFACT_BINARY_PACKAGE_2_VERSION.to_string()),
         source_name: None,
     },
     1)]
 #[case(BinaryIdentityFilter{
         name: None,
+        search_type: SearchType::Exact,
         version: None,
         source_name: None,
     },
@@ -267,6 +272,150 @@ pub async fn returns_result_for_matching_identity_filter(
             assert_eq!(version, package.version);
         }
     }
+
+    isolated_server.shutdown().await;
+}
+
+#[rstest]
+#[tokio::test]
+pub async fn exact_search_returns_only_exact_name_match(mut isolated_server: IsolatedServer) {
+    setup::multiple_imported_packages(&isolated_server.client).await;
+
+    let filter = BinaryIdentityFilter {
+        name: Some(DUMMY_MULTI_ARTIFACT_BINARY_PACKAGE_1.to_string()),
+        search_type: SearchType::Exact,
+        version: None,
+        source_name: None,
+    };
+    let results = isolated_server
+        .client
+        .get_binary_packages(None, None, Some(&filter))
+        .await
+        .map(|p| p.records)
+        .unwrap();
+
+    assert_eq!(1, results.len());
+    assert_eq!(DUMMY_MULTI_ARTIFACT_BINARY_PACKAGE_1, results[0].name);
+
+    isolated_server.shutdown().await;
+}
+
+#[rstest]
+#[tokio::test]
+pub async fn exact_search_does_not_match_partial_name(mut isolated_server: IsolatedServer) {
+    setup::multiple_imported_packages(&isolated_server.client).await;
+
+    // DUMMY_MULTI_ARTIFACT_BINARY_PACKAGE_1 is "bar"; "ba" should not match exactly
+    let filter = BinaryIdentityFilter {
+        name: Some("ba".to_string()),
+        search_type: SearchType::Exact,
+        version: None,
+        source_name: None,
+    };
+    let results = isolated_server
+        .client
+        .get_binary_packages(None, None, Some(&filter))
+        .await
+        .map(|p| p.records)
+        .unwrap();
+
+    assert!(results.is_empty());
+
+    isolated_server.shutdown().await;
+}
+
+#[rstest]
+#[tokio::test]
+pub async fn contains_search_returns_all_packages_with_substring(
+    mut isolated_server: IsolatedServer,
+) {
+    setup::multiple_imported_packages(&isolated_server.client).await;
+
+    // "ba" is a substring of "bar" and "baz"
+    let filter = BinaryIdentityFilter {
+        name: Some("ba".to_string()),
+        search_type: SearchType::Contains,
+        version: None,
+        source_name: None,
+    };
+    let results = isolated_server
+        .client
+        .get_binary_packages(None, None, Some(&filter))
+        .await
+        .map(|p| p.records)
+        .unwrap();
+
+    assert_eq!(2, results.len());
+
+    isolated_server.shutdown().await;
+}
+
+#[rstest]
+#[tokio::test]
+pub async fn starts_with_search_returns_matching_packages(mut isolated_server: IsolatedServer) {
+    setup::multiple_imported_packages(&isolated_server.client).await;
+
+    // "ba" is a prefix of "bar" and "baz"
+    let filter = BinaryIdentityFilter {
+        name: Some("ba".to_string()),
+        search_type: SearchType::StartsWith,
+        version: None,
+        source_name: None,
+    };
+    let results = isolated_server
+        .client
+        .get_binary_packages(None, None, Some(&filter))
+        .await
+        .map(|p| p.records)
+        .unwrap();
+
+    assert_eq!(2, results.len());
+
+    isolated_server.shutdown().await;
+}
+
+#[rstest]
+#[tokio::test]
+pub async fn starts_with_search_does_not_match_suffix(mut isolated_server: IsolatedServer) {
+    setup::multiple_imported_packages(&isolated_server.client).await;
+
+    // "oo" appears in "foo" as a suffix, not a prefix
+    let filter = BinaryIdentityFilter {
+        name: Some("oo".to_string()),
+        search_type: SearchType::StartsWith,
+        version: None,
+        source_name: None,
+    };
+    let results = isolated_server
+        .client
+        .get_binary_packages(None, None, Some(&filter))
+        .await
+        .map(|p| p.records)
+        .unwrap();
+
+    assert!(results.is_empty());
+
+    isolated_server.shutdown().await;
+}
+
+#[rstest]
+#[tokio::test]
+pub async fn default_search_type_is_exact(mut isolated_server: IsolatedServer) {
+    setup::multiple_imported_packages(&isolated_server.client).await;
+
+    // "ba" would match "bar"/"baz" with contains, but not with exact (default)
+    let filter = BinaryIdentityFilter {
+        name: Some("ba".to_string()),
+        ..Default::default()
+    };
+    let results = isolated_server
+        .client
+        .get_binary_packages(None, None, Some(&filter))
+        .await
+        .map(|p| p.records)
+        .unwrap();
+
+    assert!(results.is_empty());
 
     isolated_server.shutdown().await;
 }

--- a/tests/src/api/v1/package/get_source_packages.rs
+++ b/tests/src/api/v1/package/get_source_packages.rs
@@ -294,9 +294,7 @@ pub async fn returns_result_for_matching_identity_filter(
 
 #[rstest]
 #[tokio::test]
-pub async fn contains_search_returns_matching_source_packages(
-    mut isolated_server: IsolatedServer,
-) {
+pub async fn contains_search_returns_matching_source_packages(mut isolated_server: IsolatedServer) {
     setup::multiple_imported_packages(&isolated_server.client).await;
 
     // DUMMY_MULTI_ARTIFACT_SOURCE_PACKAGE is "barbaz"; "arb" is a substring

--- a/tests/src/api/v1/package/get_source_packages.rs
+++ b/tests/src/api/v1/package/get_source_packages.rs
@@ -3,7 +3,7 @@ use crate::fixtures::server::IsolatedServer;
 use crate::fixtures::*;
 use crate::setup;
 use rebuilderd_common::api::v1::{
-    OriginFilter, PackageReport, PackageRestApi, Page, SourceIdentityFilter,
+    OriginFilter, PackageReport, PackageRestApi, Page, SearchType, SourceIdentityFilter,
 };
 use rstest::rstest;
 
@@ -232,26 +232,31 @@ pub async fn returns_result_for_matching_origin_filter(
 #[rstest]
 #[case(SourceIdentityFilter{
         name: Some(DUMMY_SOURCE_PACKAGE.to_string()),
+        search_type: SearchType::Exact,
         version: None,
     },
     1)]
 #[case(SourceIdentityFilter{
         name: Some(DUMMY_MULTI_ARTIFACT_SOURCE_PACKAGE.to_string()),
+        search_type: SearchType::Exact,
         version: None,
     },
     1)]
 #[case(SourceIdentityFilter{
         name: None,
+        search_type: SearchType::Exact,
         version: Some(DUMMY_SOURCE_PACKAGE_VERSION.to_string()),
     },
     1)]
 #[case(SourceIdentityFilter{
         name: None,
+        search_type: SearchType::Exact,
         version: Some(DUMMY_MULTI_ARTIFACT_SOURCE_PACKAGE_VERSION.to_string()),
     },
     1)]
 #[case(SourceIdentityFilter{
         name: None,
+        search_type: SearchType::Exact,
         version: None,
     },
     2)]
@@ -283,6 +288,81 @@ pub async fn returns_result_for_matching_identity_filter(
             assert_eq!(version, package.version);
         }
     }
+
+    isolated_server.shutdown().await;
+}
+
+#[rstest]
+#[tokio::test]
+pub async fn contains_search_returns_matching_source_packages(
+    mut isolated_server: IsolatedServer,
+) {
+    setup::multiple_imported_packages(&isolated_server.client).await;
+
+    // DUMMY_MULTI_ARTIFACT_SOURCE_PACKAGE is "barbaz"; "arb" is a substring
+    let filter = SourceIdentityFilter {
+        name: Some("arb".to_string()),
+        search_type: SearchType::Contains,
+        version: None,
+    };
+    let results = isolated_server
+        .client
+        .get_source_packages(None, None, Some(&filter))
+        .await
+        .map(|p| p.records)
+        .unwrap();
+
+    assert_eq!(1, results.len());
+    assert_eq!(DUMMY_MULTI_ARTIFACT_SOURCE_PACKAGE, results[0].name);
+
+    isolated_server.shutdown().await;
+}
+
+#[rstest]
+#[tokio::test]
+pub async fn starts_with_search_returns_matching_source_packages(
+    mut isolated_server: IsolatedServer,
+) {
+    setup::multiple_imported_packages(&isolated_server.client).await;
+
+    // DUMMY_MULTI_ARTIFACT_SOURCE_PACKAGE is "barbaz"; "bar" is a prefix
+    let filter = SourceIdentityFilter {
+        name: Some("bar".to_string()),
+        search_type: SearchType::StartsWith,
+        version: None,
+    };
+    let results = isolated_server
+        .client
+        .get_source_packages(None, None, Some(&filter))
+        .await
+        .map(|p| p.records)
+        .unwrap();
+
+    assert_eq!(1, results.len());
+    assert_eq!(DUMMY_MULTI_ARTIFACT_SOURCE_PACKAGE, results[0].name);
+
+    isolated_server.shutdown().await;
+}
+
+#[rstest]
+#[tokio::test]
+pub async fn starts_with_search_does_not_match_suffix(mut isolated_server: IsolatedServer) {
+    setup::multiple_imported_packages(&isolated_server.client).await;
+
+    // "baz" is a suffix of "barbaz", not a prefix
+    let filter = SourceIdentityFilter {
+        name: Some("baz".to_string()),
+        search_type: SearchType::StartsWith,
+        version: None,
+    };
+    let results = isolated_server
+        .client
+        .get_source_packages(None, None, Some(&filter))
+        .await
+        .map(|p| p.records)
+        .unwrap();
+
+    assert!(results.is_empty());
 
     isolated_server.shutdown().await;
 }

--- a/tests/src/api/v1/package/submit_package_report.rs
+++ b/tests/src/api/v1/package/submit_package_report.rs
@@ -7,7 +7,7 @@ use crate::setup;
 use chrono::Utc;
 use rebuilderd_common::api::v1::{
     BuildRestApi, BuildStatus, OriginFilter, PackageReport, PackageRestApi, Priority, QueueRestApi,
-    SourceIdentityFilter,
+    SearchType, SourceIdentityFilter,
 };
 use rebuilderd_common::config::ConfigFile;
 use rstest::rstest;
@@ -519,6 +519,7 @@ pub async fn existing_rebuilds_are_copied_from_friends(
     // then, the friend of that package
     let friend_identity = SourceIdentityFilter {
         name: Some(DUMMY_BINARY_PACKAGE.to_string()),
+        search_type: SearchType::Exact,
         version: Some(DUMMY_BINARY_PACKAGE_VERSION.to_string()),
     };
 
@@ -566,6 +567,7 @@ pub async fn existing_rebuilds_are_not_copied_from_nonfriends(
     // then, the nonfriends of that package
     let friend_identity = SourceIdentityFilter {
         name: Some(DUMMY_BINARY_PACKAGE.to_string()),
+        search_type: SearchType::Exact,
         version: Some(DUMMY_BINARY_PACKAGE_VERSION.to_string()),
     };
 

--- a/tests/src/api/v1/queue/drop_queued_jobs.rs
+++ b/tests/src/api/v1/queue/drop_queued_jobs.rs
@@ -5,7 +5,7 @@ use crate::fixtures::server::IsolatedServer;
 use crate::fixtures::*;
 use crate::setup;
 use rebuilderd_common::api::v1::{
-    OriginFilter, PackageReport, PackageRestApi, QueueRestApi, SourceIdentityFilter,
+    OriginFilter, PackageReport, PackageRestApi, QueueRestApi, SearchType, SourceIdentityFilter,
 };
 use rstest::rstest;
 
@@ -112,18 +112,22 @@ pub async fn drops_correct_job_for_matching_origin_filter(
 #[rstest]
 #[case(SourceIdentityFilter{
         name: Some(DUMMY_SOURCE_PACKAGE.to_string()),
+        search_type: SearchType::Exact,
         version: None,
     })]
 #[case(SourceIdentityFilter{
         name: Some(DUMMY_MULTI_ARTIFACT_SOURCE_PACKAGE.to_string()),
+        search_type: SearchType::Exact,
         version: None,
     })]
 #[case(SourceIdentityFilter{
         name: None,
+        search_type: SearchType::Exact,
         version: Some(DUMMY_SOURCE_PACKAGE_VERSION.to_string()),
     })]
 #[case(SourceIdentityFilter{
         name: None,
+        search_type: SearchType::Exact,
         version: Some(DUMMY_MULTI_ARTIFACT_SOURCE_PACKAGE_VERSION.to_string()),
     })]
 #[tokio::test]

--- a/tests/src/api/v1/queue/get_queued_jobs.rs
+++ b/tests/src/api/v1/queue/get_queued_jobs.rs
@@ -4,7 +4,8 @@ use crate::fixtures::server::IsolatedServer;
 use crate::fixtures::*;
 use crate::setup;
 use rebuilderd_common::api::v1::{
-    OriginFilter, PackageReport, PackageRestApi, Page, QueueRestApi, SourceIdentityFilter,
+    OriginFilter, PackageReport, PackageRestApi, Page, QueueRestApi, SearchType,
+    SourceIdentityFilter,
 };
 use rstest::rstest;
 
@@ -220,26 +221,31 @@ pub async fn returns_result_for_matching_origin_filter(
 #[rstest]
 #[case(SourceIdentityFilter{
         name: Some(DUMMY_SOURCE_PACKAGE.to_string()),
+        search_type: SearchType::Exact,
         version: None,
     },
     1)]
 #[case(SourceIdentityFilter{
         name: Some(DUMMY_MULTI_ARTIFACT_SOURCE_PACKAGE.to_string()),
+        search_type: SearchType::Exact,
         version: None,
     },
     1)]
 #[case(SourceIdentityFilter{
         name: None,
+        search_type: SearchType::Exact,
         version: Some(DUMMY_SOURCE_PACKAGE_VERSION.to_string()),
     },
     1)]
 #[case(SourceIdentityFilter{
         name: None,
+        search_type: SearchType::Exact,
         version: Some(DUMMY_MULTI_ARTIFACT_SOURCE_PACKAGE_VERSION.to_string()),
     },
     1)]
 #[case(SourceIdentityFilter{
         name: None,
+        search_type: SearchType::Exact,
         version: None,
     },
     2)]

--- a/tools/src/main.rs
+++ b/tools/src/main.rs
@@ -114,6 +114,7 @@ async fn lookup_package(client: &Client, filter: PkgsFilter) -> Result<BinaryPac
         name: filter.name,
         version: None, // TODO: ls.filter.version
         source_name: None,
+        ..Default::default()
     };
 
     let mut results = client
@@ -230,6 +231,7 @@ async fn main() -> Result<()> {
                 name: ls.filter.name,
                 version: None, // TODO: ls.filter.version
                 source_name: None,
+                ..Default::default()
             };
 
             let mut page = Page {
@@ -439,6 +441,7 @@ async fn main() -> Result<()> {
             let source_identity_filter = SourceIdentityFilter {
                 name: Some(push.name),
                 version: push.version,
+                ..Default::default()
             };
 
             client


### PR DESCRIPTION
The current `name` param returns package by exact match however, I needed a more extended functionality on my FE to search by partial match and a "starts with" for an Alphabet filter.

I could have just changed how the name filter works (make the value a LIKE syntax value for example) but that would break backward compat. Second option was to add a new search param like `name_starts_with`, but then I decided on a third option to switch between modes and have `exact` be the default.

Could possibly need to have to name this `name_search_type` if you'd want to do something similar with another field (version?) but not seeing a use case rn.


Client side:
```
curl "http://localhost:8484/api/v1/packages/binary?name=nano&search_type=exact" |jq
curl "http://localhost:8484/api/v1/packages/binary?name=ano&search_type=contains" |jq
curl "http://localhost:8484/api/v1/packages/binary?name=nan&search_type=starts_with" |jq
```