### PR TITLE
Allow SyncRelease to set different source= value

### DIFF
--- a/contrib/confs/rebuilderd-sync.conf
+++ b/contrib/confs/rebuilderd-sync.conf
@@ -56,6 +56,18 @@ releases = ["sid"]
 pkgs = ["anarchism", "binutils-arm-none-eabi", "libglib2.0-bin", "libglib2.0-dev", "sniffglue", "librust-sniffglue-dev", "dfrs", "librust-dfrs-dev"]
 source = "http://deb.debian.org/debian"
 
+# example with debug packages from a different source
+[profile."debian-telegram"]
+distro = "debian"
+components = ["main"]
+architectures = ["amd64"]
+releases = [
+    "trixie-backports",
+    { name = "trixie-backports-debug", source = "http://deb.debian.org/debian-debug" }
+]
+pkgs = ["telegram-desktop*"]
+source = "http://deb.debian.org/debian"
+
 [profile."tails"]
 distro = "tails"
 architectures = ["amd64"]

--- a/tools/src/args.rs
+++ b/tools/src/args.rs
@@ -1,3 +1,4 @@
+use crate::config::SyncRelease;
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::Shell;
 use glob::Pattern;
@@ -88,7 +89,7 @@ pub struct PkgsSync {
     pub maintainers: Vec<String>,
 
     #[arg(long = "release")]
-    pub releases: Vec<String>,
+    pub releases: Vec<SyncRelease>,
 
     #[arg(long = "pkg")]
     pub pkgs: Vec<Pattern>,

--- a/tools/src/config.rs
+++ b/tools/src/config.rs
@@ -1,10 +1,12 @@
 use rebuilderd_common::errors::*;
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::convert::Infallible;
 use std::fs;
 use std::path::Path;
+use std::str::FromStr;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq)]
 pub struct SyncConfigFile {
     #[serde(rename = "profile")]
     pub profiles: HashMap<String, SyncProfile>,
@@ -18,7 +20,7 @@ impl SyncConfigFile {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq)]
 pub struct SyncProfile {
     pub distro: String,
 
@@ -31,7 +33,7 @@ pub struct SyncProfile {
     pub components: Vec<String>,
 
     #[serde(default)]
-    pub releases: Vec<String>,
+    pub releases: Vec<SyncRelease>,
 
     #[deprecated]
     pub architecture: Option<String>,
@@ -49,4 +51,129 @@ pub struct SyncProfile {
 
     #[serde(default)]
     pub excludes: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[serde(untagged)]
+pub enum SyncRelease {
+    Release(String),
+    ReleaseWithSource {
+        name: String,
+        source: Option<String>,
+    },
+}
+
+impl SyncRelease {
+    pub fn new<I: Into<String>>(release: I) -> SyncRelease {
+        SyncRelease::Release(release.into())
+    }
+
+    pub fn source<'a>(&'a self, default_source: &'a str) -> &'a str {
+        match self {
+            SyncRelease::Release(_release) => default_source,
+            SyncRelease::ReleaseWithSource { source, .. } => {
+                source.as_deref().unwrap_or(default_source)
+            }
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        match self {
+            SyncRelease::Release(release) => release,
+            SyncRelease::ReleaseWithSource { name, .. } => name,
+        }
+    }
+}
+
+impl FromStr for SyncRelease {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(SyncRelease::Release(s.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_sync_profile() {
+        let config = r#"
+[profile."debian-telegram"]
+distro = "debian"
+components = ["main"]
+architectures = ["amd64"]
+releases = ["trixie-backports"]
+pkgs = ["telegram-desktop*"]
+source = "http://deb.debian.org/debian"
+"#;
+        let config = toml::from_str::<SyncConfigFile>(config).unwrap();
+        assert_eq!(
+            config,
+            SyncConfigFile {
+                profiles: [(
+                    "debian-telegram".to_string(),
+                    SyncProfile {
+                        distro: "debian".to_string(),
+                        sync_method: None,
+                        suite: None,
+                        components: vec!["main".to_string()],
+                        releases: vec![SyncRelease::new("trixie-backports")],
+                        architecture: None,
+                        architectures: vec!["amd64".to_string()],
+                        source: "http://deb.debian.org/debian".to_string(),
+                        maintainers: vec![],
+                        pkgs: vec!["telegram-desktop*".to_string()],
+                        excludes: vec![],
+                    }
+                )]
+                .into_iter()
+                .collect()
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_sync_profile_multiple_sources() {
+        let config = r#"
+[profile."debian-telegram"]
+distro = "debian"
+components = ["main"]
+architectures = ["amd64"]
+releases = ["trixie-backports", {name = "trixie-backports-debug", source = "http://deb.debian.org/debian-debug"}]
+pkgs = ["telegram-desktop*"]
+source = "http://deb.debian.org/debian"
+"#;
+        let config = toml::from_str::<SyncConfigFile>(config).unwrap();
+        assert_eq!(
+            config,
+            SyncConfigFile {
+                profiles: [(
+                    "debian-telegram".to_string(),
+                    SyncProfile {
+                        distro: "debian".to_string(),
+                        sync_method: None,
+                        suite: None,
+                        components: vec!["main".to_string()],
+                        releases: vec![
+                            SyncRelease::new("trixie-backports"),
+                            SyncRelease::ReleaseWithSource {
+                                name: "trixie-backports-debug".to_string(),
+                                source: Some("http://deb.debian.org/debian-debug".to_string()),
+                            }
+                        ],
+                        architecture: None,
+                        architectures: vec!["amd64".to_string()],
+                        source: "http://deb.debian.org/debian".to_string(),
+                        maintainers: vec![],
+                        pkgs: vec!["telegram-desktop*".to_string()],
+                        excludes: vec![],
+                    }
+                )]
+                .into_iter()
+                .collect()
+            }
+        );
+    }
 }

--- a/tools/src/schedule/debian.rs
+++ b/tools/src/schedule/debian.rs
@@ -454,12 +454,11 @@ pub async fn sync(http: &http::Client, sync: &PkgsSync) -> Result<Vec<PackageRep
             } else {
                 component
             };
-            // Downloading source package index
-            let db_url = format!(
-                "{}/dists/{}/{}/source/Sources.xz",
-                sync.source, release, source_component
-            );
 
+            let base_url = format!("{}/dists/{}", release.source(&sync.source), release.name());
+
+            // Downloading source package index
+            let db_url = format!("{base_url}/{source_component}/source/Sources.xz");
             let bytes = fetch_url_or_path(http, &db_url).await?;
 
             info!("Building map of all source packages");
@@ -467,15 +466,16 @@ pub async fn sync(http: &http::Client, sync: &PkgsSync) -> Result<Vec<PackageRep
 
             for arch in &sync.architectures {
                 // Downloading binary package index
-                let db_url = format!(
-                    "{}/dists/{}/{}/binary-{}/Packages.xz",
-                    sync.source, release, component, arch
-                );
+                let db_url = format!("{base_url}/{component}/binary-{arch}/Packages.xz");
 
                 match fetch_url_or_path(http, &db_url).await {
                     Ok(bytes) => {
                         state.import_compressed_binary_package_file(
-                            &bytes, &sources, release, component, sync,
+                            &bytes,
+                            &sources,
+                            release.name(),
+                            component,
+                            sync,
                         )?;
                     }
                     Err(e) => {
@@ -492,6 +492,7 @@ pub async fn sync(http: &http::Client, sync: &PkgsSync) -> Result<Vec<PackageRep
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::SyncRelease;
     use std::io::Cursor;
 
     #[test]
@@ -1540,7 +1541,7 @@ SHA256: cc2081a6b2f6dcb82039b5097405b5836017a7bfc54a78eba36b656549e17c92
             architectures: vec!["amd64".to_string()],
             print_json: true,
             maintainers: vec![],
-            releases: vec!["sid".to_string(), "testing".to_string()],
+            releases: vec![SyncRelease::new("sid"), SyncRelease::new("testing")],
             pkgs: vec![],
             excludes: vec![],
             sync_method: None,
@@ -1613,7 +1614,7 @@ SHA256: cc2081a6b2f6dcb82039b5097405b5836017a7bfc54a78eba36b656549e17c92
             architectures: vec!["amd64".to_string(), "all".to_string()],
             print_json: true,
             maintainers: vec![],
-            releases: vec!["sid".to_string(), "testing".to_string()],
+            releases: vec![SyncRelease::new("sid"), SyncRelease::new("testing")],
             pkgs: vec![],
             excludes: vec![],
             sync_method: None,

--- a/tools/src/schedule/debian.rs
+++ b/tools/src/schedule/debian.rs
@@ -1,4 +1,5 @@
 use crate::args::PkgsSync;
+use crate::config::SyncRelease;
 use crate::schedule::{Pkg, fetch_url_or_path};
 use rebuilderd_common::api::v1::{BinaryPackageReport, PackageReport, SourcePackageReport};
 use rebuilderd_common::errors::*;
@@ -369,8 +370,8 @@ impl SyncState {
     pub fn import_binary_pkg(
         &mut self,
         pkg: DebianBinPkg,
-        sources: &SourcePkgBucket,
-        release: &str,
+        source_pkgs: &SourcePkgBucket,
+        release: &SyncRelease,
         component: &str,
         sync: &PkgsSync,
     ) -> Result<()> {
@@ -382,14 +383,15 @@ impl SyncState {
 
         debug!("Found binary package: {:?} {:?}", pkg.name, pkg.version);
 
-        match sources.get(&pkg) {
-            Ok(source) => {
+        match source_pkgs.get(&pkg) {
+            Ok(source_pkg) => {
                 debug!(
                     "Matched binary package to source package: {:?} {:?}",
-                    source.base, source.version
+                    source_pkg.base, source_pkg.version
                 );
 
-                self.push(&source, pkg, &sync.source, release, component);
+                let source = release.source(&sync.source);
+                self.push(&source_pkg, pkg, source, release.name(), component);
             }
             Err(e) => {
                 warn!("{}, skipping", e)
@@ -410,14 +412,14 @@ impl SyncState {
     pub fn import_compressed_binary_package_file(
         &mut self,
         bytes: &[u8],
-        sources: &SourcePkgBucket,
-        release: &str,
+        source_pkgs: &SourcePkgBucket,
+        release: &SyncRelease,
         component: &str,
         sync: &PkgsSync,
     ) -> Result<()> {
-        self.create_all_release_groups(release, component, sync);
+        self.create_all_release_groups(release.name(), component, sync);
         for pkg in extract_pkgs_compressed::<DebianBinPkg>(bytes)? {
-            self.import_binary_pkg(pkg, sources, release, component, sync)?;
+            self.import_binary_pkg(pkg, source_pkgs, release, component, sync)?;
         }
         Ok(())
     }
@@ -425,14 +427,14 @@ impl SyncState {
     pub fn import_uncompressed_binary_package_file(
         &mut self,
         bytes: &[u8],
-        sources: &SourcePkgBucket,
-        release: &str,
+        source_pkgs: &SourcePkgBucket,
+        release: &SyncRelease,
         component: &str,
         sync: &PkgsSync,
     ) -> Result<()> {
-        self.create_all_release_groups(release, component, sync);
+        self.create_all_release_groups(release.name(), component, sync);
         for pkg in extract_pkgs_uncompressed::<DebianBinPkg, _>(bytes)? {
-            self.import_binary_pkg(pkg, sources, release, component, sync)?;
+            self.import_binary_pkg(pkg, source_pkgs, release, component, sync)?;
         }
         Ok(())
     }
@@ -442,7 +444,7 @@ pub async fn sync(http: &http::Client, sync: &PkgsSync) -> Result<Vec<PackageRep
     let mut state = SyncState::new();
 
     for release in &sync.releases {
-        let mut sources = SourcePkgBucket::new();
+        let mut source_pkgs = SourcePkgBucket::new();
 
         for component in &sync.components {
             let source_component = if component.ends_with("/debian-installer") {
@@ -462,7 +464,7 @@ pub async fn sync(http: &http::Client, sync: &PkgsSync) -> Result<Vec<PackageRep
             let bytes = fetch_url_or_path(http, &db_url).await?;
 
             info!("Building map of all source packages");
-            sources.import_compressed_source_package_file(&bytes)?;
+            source_pkgs.import_compressed_source_package_file(&bytes)?;
 
             for arch in &sync.architectures {
                 // Downloading binary package index
@@ -472,8 +474,8 @@ pub async fn sync(http: &http::Client, sync: &PkgsSync) -> Result<Vec<PackageRep
                     Ok(bytes) => {
                         state.import_compressed_binary_package_file(
                             &bytes,
-                            &sources,
-                            release.name(),
+                            &source_pkgs,
+                            release,
                             component,
                             sync,
                         )?;
@@ -502,7 +504,7 @@ mod tests {
             .import_uncompressed_binary_package_file(
                 b"",
                 &SourcePkgBucket::new(),
-                "trixie-proposed-updates",
+                &SyncRelease::new("trixie-proposed-updates"),
                 "main",
                 &PkgsSync {
                     distro: "debian".to_string(),
@@ -1188,14 +1190,14 @@ Section: mail
 ";
         let cursor = Cursor::new(bytes);
 
-        let mut sources = SourcePkgBucket::new();
-        sources
+        let mut source_pkgs = SourcePkgBucket::new();
+        source_pkgs
             .import_uncompressed_source_package_file(cursor)
             .unwrap();
 
         let mut state = SyncState::new();
         for bin in bin_pkgs {
-            let src = sources.get(&bin).unwrap();
+            let src = source_pkgs.get(&bin).unwrap();
             state.push(&src, bin, "https://deb.debian.org/debian", "sid", "main");
         }
 
@@ -1428,8 +1430,8 @@ Section: misc
 
 ";
 
-        let mut sources = SourcePkgBucket::new();
-        sources
+        let mut source_pkgs = SourcePkgBucket::new();
+        source_pkgs
             .import_uncompressed_source_package_file(sources_bytes.as_bytes())
             .unwrap();
 
@@ -1438,7 +1440,7 @@ Section: misc
 
         // test first package (with Extra-Source-Only)
         let pkg = pkgs.next().unwrap();
-        let src = sources.get(&pkg).unwrap();
+        let src = source_pkgs.get(&pkg).unwrap();
         assert_eq!(
             src,
             DebianSourcePkg {
@@ -1453,7 +1455,7 @@ Section: misc
 
         // test second package (without Extra-Source-Only)
         let pkg = pkgs.next().unwrap();
-        let src = sources.get(&pkg).unwrap();
+        let src = source_pkgs.get(&pkg).unwrap();
         assert_eq!(
             src,
             DebianSourcePkg {
@@ -1505,8 +1507,8 @@ Priority: optional
 Section: misc
 
 ";
-        let mut sources = SourcePkgBucket::new();
-        sources
+        let mut source_pkgs = SourcePkgBucket::new();
+        source_pkgs
             .import_uncompressed_source_package_file(&sources_bytes[..])
             .unwrap();
 
@@ -1549,10 +1551,22 @@ SHA256: cc2081a6b2f6dcb82039b5097405b5836017a7bfc54a78eba36b656549e17c92
 
         // add the package list twice, to simulate importing sid and testing
         state
-            .import_uncompressed_binary_package_file(&bytes[..], &sources, "sid", "main", &sync)
+            .import_uncompressed_binary_package_file(
+                &bytes[..],
+                &source_pkgs,
+                &SyncRelease::new("sid"),
+                "main",
+                &sync,
+            )
             .unwrap();
         state
-            .import_uncompressed_binary_package_file(&bytes[..], &sources, "testing", "main", &sync)
+            .import_uncompressed_binary_package_file(
+                &bytes[..],
+                &source_pkgs,
+                &SyncRelease::new("testing"),
+                "main",
+                &sync,
+            )
             .unwrap();
 
         let mut reports = HashMap::new();
@@ -1713,12 +1727,18 @@ MD5sum: e088e49616de39f4cfa162959335340e
 SHA256: 89c378d37058ea2a6c5d4bb2c1d47c4810f7504bde9e4d8142ac9781ce9df002
 
 "[..]);
-        let mut sources = SourcePkgBucket::new();
-        sources
+        let mut source_pkgs = SourcePkgBucket::new();
+        source_pkgs
             .import_uncompressed_source_package_file(source)
             .unwrap();
         state
-            .import_uncompressed_binary_package_file(binary, &sources, "sid", "main", &sync)
+            .import_uncompressed_binary_package_file(
+                binary,
+                &source_pkgs,
+                &SyncRelease::new("sid"),
+                "main",
+                &sync,
+            )
             .unwrap();
 
         // testing
@@ -1787,12 +1807,18 @@ MD5sum: e088e49616de39f4cfa162959335340e
 SHA256: 89c378d37058ea2a6c5d4bb2c1d47c4810f7504bde9e4d8142ac9781ce9df002
 
 ");
-        let mut sources = SourcePkgBucket::new();
-        sources
+        let mut source_pkgs = SourcePkgBucket::new();
+        source_pkgs
             .import_uncompressed_source_package_file(&source[..])
             .unwrap();
         state
-            .import_uncompressed_binary_package_file(binary, &sources, "testing", "main", &sync)
+            .import_uncompressed_binary_package_file(
+                binary,
+                &source_pkgs,
+                &SyncRelease::new("testing"),
+                "main",
+                &sync,
+            )
             .unwrap();
 
         let mut reports = HashMap::new();

--- a/tools/src/schedule/debian.rs
+++ b/tools/src/schedule/debian.rs
@@ -4,7 +4,7 @@ use crate::schedule::{Pkg, fetch_url_or_path};
 use rebuilderd_common::api::v1::{BinaryPackageReport, PackageReport, SourcePackageReport};
 use rebuilderd_common::errors::*;
 use rebuilderd_common::http;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io::BufReader;
 use std::io::prelude::*;
 use xz2::read::XzDecoder;
@@ -288,7 +288,7 @@ pub fn extract_pkgs_uncompressed<T: AnyhowTryFrom<NewPkg>, R: BufRead>(r: R) -> 
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct SyncState {
-    reports: HashMap<(String, String, String), PackageReport>,
+    reports: BTreeMap<(String, String, String), PackageReport>,
 }
 
 impl SyncState {
@@ -759,7 +759,7 @@ Section: misc
         let mut state = SyncState::new();
         state.push(&src, bin, "https://deb.debian.org/debian", "sid", "main");
 
-        let mut reports = HashMap::new();
+        let mut reports = BTreeMap::new();
         reports.insert(("sid".to_string(), "main".to_string(), "all".to_string()), PackageReport {
             distribution: "debian".to_string(),
             release: Some("sid".to_string()),
@@ -871,7 +871,7 @@ Section: misc
             );
         }
 
-        let mut reports = HashMap::new();
+        let mut reports = BTreeMap::new();
         reports.insert(("sid".to_string(), "main".to_string(), "amd64".to_string()), PackageReport {
             distribution: "debian".to_string(),
             release: Some("sid".to_string()),
@@ -1201,7 +1201,7 @@ Section: mail
             state.push(&src, bin, "https://deb.debian.org/debian", "sid", "main");
         }
 
-        let mut reports = HashMap::new();
+        let mut reports = BTreeMap::new();
         reports.insert(("sid".to_string(), "main".to_string(), "amd64".to_string()), PackageReport {
             distribution: "debian".to_string(),
             release: Some("sid".to_string()),
@@ -1569,7 +1569,7 @@ SHA256: cc2081a6b2f6dcb82039b5097405b5836017a7bfc54a78eba36b656549e17c92
             )
             .unwrap();
 
-        let mut reports = HashMap::new();
+        let mut reports = BTreeMap::new();
         reports.insert(("sid".to_string(), "main".to_string(), "amd64".to_string()), PackageReport {
             distribution: "debian".to_string(),
             release: Some("sid".to_string()),
@@ -1821,7 +1821,7 @@ SHA256: 89c378d37058ea2a6c5d4bb2c1d47c4810f7504bde9e4d8142ac9781ce9df002
             )
             .unwrap();
 
-        let mut reports = HashMap::new();
+        let mut reports = BTreeMap::new();
 
         reports.insert(("sid".to_string(), "main".to_string(), "all".to_string()),
            PackageReport {
@@ -1916,5 +1916,116 @@ SHA256: 89c378d37058ea2a6c5d4bb2c1d47c4810f7504bde9e4d8142ac9781ce9df002
         );
 
         assert_eq!(state, SyncState { reports });
+    }
+
+    #[test]
+    fn test_release_with_source_override() {
+        let sources_bytes = b"Package: rust-sniffglue
+Binary: librust-sniffglue-dev, sniffglue, sniffglue-dbgsym
+Version: 0.14.0-2
+Maintainer: Debian Rust Maintainers <pkg-rust-maintainers@alioth-lists.debian.net>
+Uploaders: kpcyrd <git@rxv.cc>
+Architecture: any
+Directory: pool/main/r/rust-sniffglue
+Priority: optional
+Section: misc
+
+";
+        let mut source_pkgs = SourcePkgBucket::new();
+        source_pkgs
+            .import_uncompressed_source_package_file(&sources_bytes[..])
+            .unwrap();
+
+        let pkg_bytes = b"Package: sniffglue
+Source: rust-sniffglue
+Version: 0.14.0-2
+Architecture: amd64
+Filename: pool/main/r/rust-sniffglue/sniffglue_0.14.0-2_amd64.deb
+
+";
+
+        let debug_pkg_bytes = b"Package: sniffglue-dbgsym
+Source: rust-sniffglue
+Version: 0.14.0-2
+Architecture: amd64
+Filename: pool/main/r/rust-sniffglue/sniffglue-dbgsym_0.14.0-2_amd64.deb
+
+";
+
+        let mut state = SyncState::new();
+        let sync = PkgsSync {
+            distro: "debian".to_string(),
+            components: vec!["main".to_string()],
+            source: "http://deb.debian.org/debian".to_string(),
+            architectures: vec!["amd64".to_string()],
+            print_json: true,
+            maintainers: vec![],
+            releases: vec![/* this is not used during this test */],
+            pkgs: vec![],
+            excludes: vec![],
+            sync_method: None,
+        };
+
+        for (release, bytes) in [
+            (SyncRelease::new("trixie"), &pkg_bytes[..]),
+            (
+                SyncRelease::ReleaseWithSource {
+                    name: "trixie-debug".to_string(),
+                    source: Some("http://deb.debian.org/debian-debug".to_string()),
+                },
+                &debug_pkg_bytes[..],
+            ),
+        ] {
+            state
+                .import_uncompressed_binary_package_file(
+                    bytes,
+                    &source_pkgs,
+                    &release,
+                    "main",
+                    &sync,
+                )
+                .unwrap();
+        }
+
+        let reports = state.to_vec();
+        assert_eq!(
+            reports,
+            vec![
+                PackageReport {
+                    distribution: "debian".to_string(),
+                    release: Some("trixie".to_string()),
+                    component: Some("main".to_string()),
+                    architecture: "amd64".to_string(),
+                    packages: vec![SourcePackageReport {
+                        name: "rust-sniffglue".to_string(),
+                        version: "0.14.0-2".to_string(),
+                        url: "https://buildinfos.debian.net/buildinfo-pool/r/rust-sniffglue/rust-sniffglue_0.14.0-2_amd64.buildinfo".to_string(),
+                        artifacts: vec![BinaryPackageReport {
+                            name: "sniffglue".to_string(),
+                            version: "0.14.0-2".to_string(),
+                            architecture: "amd64".to_string(),
+                            url: "http://deb.debian.org/debian/pool/main/r/rust-sniffglue/sniffglue_0.14.0-2_amd64.deb".to_string(),
+                        }]
+                    }]
+                },
+                PackageReport {
+                    distribution: "debian".to_string(),
+                    release: Some("trixie-debug".to_string()),
+                    component: Some("main".to_string()),
+                    architecture: "amd64".to_string(),
+                    packages: vec![SourcePackageReport {
+                        name: "rust-sniffglue".to_string(),
+                        version: "0.14.0-2".to_string(),
+                        url: "https://buildinfos.debian.net/buildinfo-pool/r/rust-sniffglue/rust-sniffglue_0.14.0-2_amd64.buildinfo".to_string(),
+                        artifacts: vec![BinaryPackageReport {
+                            name: "sniffglue-dbgsym".to_string(),
+                            version: "0.14.0-2".to_string(),
+                            architecture: "amd64".to_string(),
+                            url: "http://deb.debian.org/debian-debug/pool/main/r/rust-sniffglue/sniffglue-dbgsym_0.14.0-2_amd64.deb".to_string()
+                        }]
+                    }]
+                },
+            ]
+        );
     }
 }

--- a/tools/src/schedule/debian.rs
+++ b/tools/src/schedule/debian.rs
@@ -447,15 +447,9 @@ pub async fn sync(http: &http::Client, sync: &PkgsSync) -> Result<Vec<PackageRep
         let mut source_pkgs = SourcePkgBucket::new();
 
         for component in &sync.components {
-            let source_component = if component.ends_with("/debian-installer") {
-                if let Some((a, _)) = component.split_once('/') {
-                    a
-                } else {
-                    component
-                }
-            } else {
-                component
-            };
+            let source_component = component
+                .strip_suffix("/debian-installer")
+                .unwrap_or(component);
 
             let base_url = format!("{}/dists/{}", release.source(&sync.source), release.name());
 

--- a/tools/src/schedule/fedora.rs
+++ b/tools/src/schedule/fedora.rs
@@ -14,17 +14,18 @@ pub async fn sync(http: &http::Client, sync: &PkgsSync) -> Result<Vec<PackageRep
     for release in &sync.releases {
         for component in &sync.components {
             for arch in &sync.architectures {
-                let url = format!(
-                    "{}/{}/{}/{}/os/",
+                let base_url = format!(
+                    "{}/{}/{}/{}/os",
                     release.source(&sync.source),
                     release.name(),
                     component,
                     arch
                 );
-                let bytes = fetch_url_or_path(http, &format!("{url}repodata/repomd.xml")).await?;
+                let bytes =
+                    fetch_url_or_path(http, &format!("{base_url}/repodata/repomd.xml")).await?;
                 let location = get_primary_location_from_xml(&bytes)?;
 
-                let bytes = fetch_url_or_path(http, &format!("{url}{location}")).await?;
+                let bytes = fetch_url_or_path(http, &format!("{base_url}/{location}")).await?;
                 info!("Parsing index ({} bytes)...", bytes.len());
 
                 let comp = decompress::detect_compression(&bytes);
@@ -46,7 +47,7 @@ pub async fn sync(http: &http::Client, sync: &PkgsSync) -> Result<Vec<PackageRep
                         continue;
                     }
 
-                    let url = format!("{url}{}", pkg.location.href);
+                    let url = format!("{base_url}/{}", pkg.location.href);
                     let version = format!("{}-{}", pkg.version.ver, pkg.version.rel);
                     let artifact = BinaryPackageReport {
                         name: pkg.name,

--- a/tools/src/schedule/fedora.rs
+++ b/tools/src/schedule/fedora.rs
@@ -14,7 +14,13 @@ pub async fn sync(http: &http::Client, sync: &PkgsSync) -> Result<Vec<PackageRep
     for release in &sync.releases {
         for component in &sync.components {
             for arch in &sync.architectures {
-                let url = format!("{}/{}/{}/{}/os/", sync.source, release, component, arch);
+                let url = format!(
+                    "{}/{}/{}/{}/os/",
+                    release.source(&sync.source),
+                    release.name(),
+                    component,
+                    arch
+                );
                 let bytes = fetch_url_or_path(http, &format!("{url}repodata/repomd.xml")).await?;
                 let location = get_primary_location_from_xml(&bytes)?;
 

--- a/tools/src/schedule/tails.rs
+++ b/tools/src/schedule/tails.rs
@@ -18,7 +18,7 @@ pub async fn sync(http: &http::Client, sync: &PkgsSync) -> Result<Vec<PackageRep
             url.path_segments_mut()
                 .map_err(|_| anyhow!("cannot be base"))?
                 .pop_if_empty()
-                .push(release);
+                .push(release.name());
 
             info!("Downloading directory list from {}", url);
             let directory_list = http
@@ -31,7 +31,7 @@ pub async fn sync(http: &http::Client, sync: &PkgsSync) -> Result<Vec<PackageRep
 
             let mut report = PackageReport {
                 distribution: "tails".to_string(),
-                release: Some(release.clone()),
+                release: Some(release.name().to_string()),
                 component: None,
                 architecture: architecture.clone(),
                 packages: Vec::new(),
@@ -59,7 +59,7 @@ pub async fn sync(http: &http::Client, sync: &PkgsSync) -> Result<Vec<PackageRep
                     .map_err(|_| anyhow!("cannot be base"))?
                     .pop_if_empty()
                     .extend(&[
-                        release,
+                        release.name(),
                         &format!("tails-{architecture}-{version}"),
                         &filename,
                     ]);

--- a/tools/src/schedule/tails.rs
+++ b/tools/src/schedule/tails.rs
@@ -6,13 +6,13 @@ use regex::Regex;
 use url::Url;
 
 pub async fn sync(http: &http::Client, sync: &PkgsSync) -> Result<Vec<PackageReport>> {
-    let source = sync
-        .source
-        .parse::<Url>()
-        .context("Failed to parse source as url")?;
-
     let mut reports = Vec::new();
     for release in &sync.releases {
+        let source = release
+            .source(&sync.source)
+            .parse::<Url>()
+            .context("Failed to parse source as url")?;
+
         for architecture in &sync.architectures {
             let mut url = source.clone();
             url.path_segments_mut()


### PR DESCRIPTION
This allows a release to use a different mirror base url. This is useful for having `-dbgsym` as part of the same profile (and benefit from having them grouped with the other builds).