### PR TITLE
Make udeb a separate component

### DIFF
--- a/tools/src/schedule/debian.rs
+++ b/tools/src/schedule/debian.rs
@@ -445,10 +445,19 @@ pub async fn sync(http: &http::Client, sync: &PkgsSync) -> Result<Vec<PackageRep
         let mut sources = SourcePkgBucket::new();
 
         for component in &sync.components {
+            let source_component = if component.ends_with("/debian-installer") {
+                if let Some((a, _)) = component.split_once('/') {
+                    a
+                } else {
+                    component
+                }
+            } else {
+                component
+            };
             // Downloading source package index
             let db_url = format!(
                 "{}/dists/{}/{}/source/Sources.xz",
-                sync.source, release, component
+                sync.source, release, source_component
             );
 
             let bytes = fetch_url_or_path(http, &db_url).await?;
@@ -457,27 +466,20 @@ pub async fn sync(http: &http::Client, sync: &PkgsSync) -> Result<Vec<PackageRep
             sources.import_compressed_source_package_file(&bytes)?;
 
             for arch in &sync.architectures {
-                for db_url in [
-                    // Binary package index
-                    format!(
-                        "{}/dists/{}/{}/binary-{}/Packages.xz",
-                        sync.source, release, component, arch
-                    ),
-                    // Binary installer package index
-                    format!(
-                        "{}/dists/{}/{}/debian-installer/binary-{}/Packages.xz",
-                        sync.source, release, component, arch
-                    ),
-                ] {
-                    match fetch_url_or_path(http, &db_url).await {
-                        Ok(bytes) => {
-                            state.import_compressed_binary_package_file(
-                                &bytes, &sources, release, component, sync,
-                            )?;
-                        }
-                        Err(e) => {
-                            warn!("{}, skipping", e);
-                        }
+                // Downloading binary package index
+                let db_url = format!(
+                    "{}/dists/{}/{}/binary-{}/Packages.xz",
+                    sync.source, release, component, arch
+                );
+
+                match fetch_url_or_path(http, &db_url).await {
+                    Ok(bytes) => {
+                        state.import_compressed_binary_package_file(
+                            &bytes, &sources, release, component, sync,
+                        )?;
+                    }
+                    Err(e) => {
+                        warn!("{}, skipping", e);
                     }
                 }
             }


### PR DESCRIPTION
We added .udeb support in #203 by automatically adding them together
with the normal package (as they are build together). This results in
them being listed with component main instead of main/debian-installer
which breaks assumptions on udd.debian.org when importing the data.
Instead add them as a separate component during sync, like this:

components = [ "main", "non-free-firmware", "main/debian-installer" ]

This reverts 0bafec7 and b2480e2.