### PR TITLE
Rebuild Fedora packages with fedora-repro-build

### DIFF
--- a/worker/rebuilder-fedora.sh
+++ b/worker/rebuilder-fedora.sh
@@ -1,2 +1,9 @@
 #!/bin/sh
-echo hello
+
+set -xe
+
+rpmfile="${1}"
+# extract nvr
+nvr=$(rpm -qp --queryformat '%{SOURCERPM}' ${rpmfile} | sed s'/.src.rpm$//')
+
+fedora-repro-build "${nvr}"

--- a/worker/rebuilder-fedora.sh
+++ b/worker/rebuilder-fedora.sh
@@ -4,6 +4,6 @@ set -xe
 
 rpmfile="${1}"
 # extract nvr
-nvr=$(rpm -qp --queryformat '%{SOURCERPM}' ${rpmfile} | sed s'/.src.rpm$//')
+nvr=$(rpm -qp --queryformat '%{SOURCERPM}' "${rpmfile}" | sed s'/.src.rpm$//')
 
 fedora-repro-build "${nvr}"


### PR DESCRIPTION
The `fedora-repro-build` is provided by `fedora-repro` and supports rebuilding Fedora packages.