### PR TITLE
Expose exit code of rebuilds

### DIFF
--- a/worker/src/rebuild.rs
+++ b/worker/src/rebuild.rs
@@ -267,7 +267,10 @@ async fn verify(
         envs,
     };
 
-    proc::run(bin.as_ref(), &[input_path], opts, log).await?;
+    let exit_ok = proc::run(bin.as_ref(), &[input_path], opts, log).await?;
+    if !exit_ok {
+        bail!("Rebuild backend exited with a non-zero status");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
If the rebuild fails, i.e. due to low storage, missing dependencies or other reason based on the setup, not the software itself, expose that error. As a result, such package is marked as FAIL instead of BAD, helping an investigator to distinguish package issues with build system issues.