### PR TITLE
worker: pass the build input URL to backends

### DIFF
--- a/worker/src/rebuild.rs
+++ b/worker/src/rebuild.rs
@@ -258,6 +258,13 @@ async fn verify(
 
     let mut envs = HashMap::new();
     envs.insert("REBUILDERD_OUTDIR".into(), path_to_string(out_dir)?);
+    // Expose the build input's URL (the already-existing ctx.input_url that
+    // download() fetched) so backends whose input isn't self-describing can
+    // recover build identity from the path — e.g. the OpenWrt apk backend
+    // derives release/arch/feed from the .apk URL.
+    if let Some(input_url) = &ctx.input_url {
+        envs.insert("REBUILDERD_INPUT_URL".into(), input_url.clone());
+    }
 
     let opts = proc::Options {
         timeout: Duration::from_secs(timeout),


### PR DESCRIPTION
Backends are now invoked as `<backend> <path> <url>`: the downloaded
build input followed by the URL it was fetched from. When no separate
input URL is set, the first artifact is the build input and its URL is
passed, so the URL argument is always present.

Backends whose input file isn't self-describing can then recover the
build identity from the URL path — e.g. an OpenWrt apk carries neither
its architecture nor release, so the backend derives them from the
.apk URL.

A positional argument (rather than an environment variable) extends
naturally to multiple build inputs later on, as `<path> <url>` pairs.
Existing backends only read $1 and are unaffected.

Signed-off-by: Paul Spooren <mail@aparcar.org>